### PR TITLE
feat: Implement org admin user management features

### DIFF
--- a/backend/src/handlers/org.rs
+++ b/backend/src/handlers/org.rs
@@ -1,57 +1,501 @@
-use actix_web::{web, get, post, HttpResponse};
-use serde::Deserialize;
-use sqlx::PgPool;
-use crate::models::{Organization, NewOrganization, OrgSettings}; // OrgSettings for create_org, Organization for list_orgs
+use actix_web::{web, get, post, HttpResponse, Scope};
+use serde::{Deserialize, Serialize};
+use sqlx::{FromRow, PgPool};
+use uuid::Uuid;
+use crate::models::{Organization, NewOrganization, OrgSettings, User as UserModel, NewUser};
 use crate::middleware::auth::AuthUser;
-use log; // Added for logging
+use crate::email::send_email; // For sending invitation emails
+use argon2::{Argon2, PasswordHasher}; // For placeholder password in invite
+use argon2::password_hash::SaltString; // For placeholder password in invite
+use rand::Rng; // For generating random passwords
+use chrono::{DateTime, Utc};
+use log;
+use serde_json;
+
 
 #[derive(Deserialize)]
 pub struct OrgInput { pub name: String }
 
+// Response struct for users within an organization, tailored for org admins
+#[derive(Serialize, FromRow, Debug)]
+pub struct OrgUserView {
+    id: Uuid,
+    email: String,
+    role: String, // Should typically be 'user' for users managed by an org_admin
+    confirmed: bool,
+    is_active: bool,
+    created_at: DateTime<Utc>,
+    deactivated_at: Option<DateTime<Utc>>,
+}
+
+// Payload for inviting a user to the organization
+#[derive(Deserialize, Debug)]
+pub struct OrgInviteUserPayload {
+    email: String,
+}
+
 #[post("/orgs")]
-async fn create_org(data: web::Json<OrgInput>, _user: AuthUser, pool: web::Data<PgPool>) -> HttpResponse {
-    let org = NewOrganization { name: data.name.clone() };
-    match Organization::create(&pool, org).await {
-        Ok(o) => {
-            let _ = OrgSettings::create_default(&pool, o.id).await;
-            HttpResponse::Ok().json(o)
+async fn create_org(data: web::Json<OrgInput>, user: AuthUser, pool: web::Data<PgPool>) -> HttpResponse {
+    // Only global admins can create organizations
+    if user.role != "admin" {
+        return HttpResponse::Forbidden().json(serde_json::json!({"error": "You do not have permission to create organizations."}));
+    }
+
+    let org_name = data.name.trim();
+    if org_name.is_empty() {
+        return HttpResponse::BadRequest().json(serde_json::json!({"error": "Organization name cannot be empty."}));
+    }
+
+    let new_org = NewOrganization { name: org_name.to_string() };
+    match Organization::create(&pool, new_org).await {
+        Ok(created_org) => {
+            match OrgSettings::create_default(&pool, created_org.id).await {
+                Ok(_) => HttpResponse::Ok().json(created_org),
+                Err(e) => {
+                    log::error!("Failed to create default settings for new org {}: {:?}", created_org.id, e);
+                    // Organization was created, but settings failed. This is a partial success.
+                    // Depending on requirements, might want to roll back org creation or just log and return org.
+                    // For now, returning the org but logging the error.
+                    HttpResponse::Ok().json(serde_json::json!({
+                        "warning": "Organization created, but default settings failed to initialize.",
+                        "organization": created_org
+                    }))
+                }
+            }
         },
-        Err(_) => HttpResponse::InternalServerError().finish(),
+        Err(sqlx::Error::Database(db_err)) if db_err.constraint() == Some("organizations_name_key") => {
+            HttpResponse::Conflict().json(serde_json::json!({"error": "An organization with this name already exists."}))
+        }
+        Err(e) => {
+            log::error!("Failed to create organization '{}': {:?}", org_name, e);
+            HttpResponse::InternalServerError().json(serde_json::json!({"error": "Failed to create organization."}))
+        }
     }
 }
 
 #[get("/orgs")]
-async fn list_orgs(user: AuthUser, pool: web::Data<PgPool>) -> HttpResponse { // Changed _user to user
+async fn list_orgs(user: AuthUser, pool: web::Data<PgPool>) -> HttpResponse {
     let result = if user.role == "admin" {
-        // Global admin gets all organizations
         Organization::all(pool.as_ref()).await
     } else {
-        // Non-global admins (e.g., "user", future "org_admin") get only their own organization
+        // Non-global admins (e.g., "user", "org_admin") get only their own organization
         sqlx::query_as::<_, Organization>("SELECT id, name, api_key FROM organizations WHERE id = $1")
             .bind(user.org_id)
             .fetch_optional(pool.as_ref())
             .await
-            .map(|opt_org| opt_org.map_or_else(Vec::new, |org| vec![org])) // Convert Option<Org> to Vec<Org>
-            // For sqlx::Error conversion, if not using map_err on the query chain:
+            .map(|opt_org| opt_org.map_or_else(Vec::new, |org| vec![org]))
             .map_err(|e| {
-                // Log the original sqlx error before converting to a generic one if needed
-                log::error!("Database error fetching single organization: {:?}", e);
-                // This specific conversion might not be needed if Organization::all already returns sqlx::Error
-                // and the outer match handles it. This is more for converting a specific query error type.
-                // For now, assume the error type from this branch is compatible with Organization::all's error type.
+                log::error!("Database error fetching single organization for user {}: {:?}", user.user_id, e);
                 e
             })
     };
 
     match result {
         Ok(list) => HttpResponse::Ok().json(list),
-        Err(e) => {
-            log::error!("Failed to list organizations: {:?}", e);
-            HttpResponse::InternalServerError().json(serde_json::json!({"error": "Failed to retrieve organizations"}))
+        Err(_) => {
+            // Specific error already logged
+            HttpResponse::InternalServerError().json(serde_json::json!({"error": "Failed to retrieve organizations."}))
         }
     }
 }
 
+async fn get_organization_users(user: AuthUser, pool: web::Data<PgPool>) -> HttpResponse {
+    if user.role != "org_admin" && user.role != "admin" { // Allow global admin to use this too
+        return HttpResponse::Forbidden().json(serde_json::json!({"error": "You do not have permission to view users for this organization."}));
+    }
+
+    // For org_admin, org_id is from their session. For global admin, they'd need to specify.
+    // This endpoint is /me/users, so it's implicitly the authenticated user's org.
+    // If a global admin needs to see users for *any* org, they should use /admin/users or a new specific endpoint.
+    // So, we strictly use user.org_id.
+    if user.role == "org_admin" && user.org_id == Uuid::nil() { // Nil UUID check
+         return HttpResponse::BadRequest().json(serde_json::json!({"error": "Organization admin is not associated with an organization."}));
+    }
+
+
+    let query = "
+        SELECT id, email, role, confirmed, is_active, created_at, deactivated_at
+        FROM users
+        WHERE org_id = $1
+        ORDER BY email ASC
+    ";
+
+    match sqlx::query_as::<_, OrgUserView>(query)
+        .bind(user.org_id)
+        .fetch_all(pool.as_ref())
+        .await
+    {
+        Ok(users) => HttpResponse::Ok().json(users),
+        Err(e) => {
+            log::error!("Failed to fetch users for organization {}: {:?}", user.org_id, e);
+            HttpResponse::InternalServerError().json(serde_json::json!({"error": "Failed to retrieve users for the organization."}))
+        }
+    }
+}
+
+async fn invite_user_to_organization(
+    current_org_admin: AuthUser,
+    payload: web::Json<OrgInviteUserPayload>,
+    pool: web::Data<PgPool>,
+) -> HttpResponse {
+    if current_org_admin.role != "org_admin" {
+        return HttpResponse::Forbidden().json(serde_json::json!({"error": "Only organization administrators can invite users to their organization."}));
+    }
+
+    let target_email = payload.email.trim().to_lowercase();
+    if target_email.is_empty() || !target_email.contains('@') {
+        return HttpResponse::BadRequest().json(serde_json::json!({"error": "Invalid email address provided."}));
+    }
+
+    // Check if user already exists
+    match UserModel::find_by_email(&pool, &target_email).await {
+        Ok(existing_user) => {
+            // User exists. Check if they are already in this org.
+            if existing_user.org_id == current_org_admin.org_id {
+                return HttpResponse::Conflict().json(serde_json::json!({"error": "This user is already a member of your organization."}));
+            } else {
+                // User exists but in a different organization.
+                // Org admins cannot pull users from other orgs. Global admin task.
+                return HttpResponse::Conflict().json(serde_json::json!({
+                    "error": "This email address is already associated with an account in a different organization. Please contact a global administrator if you need to move this user."
+                }));
+            }
+        }
+        Err(sqlx::Error::RowNotFound) => {
+            // User does not exist, proceed to create and invite.
+        }
+        Err(e) => {
+            log::error!("Database error when checking for existing user by email '{}': {:?}", target_email, e);
+            return HttpResponse::InternalServerError().json(serde_json::json!({"error": "Error checking user existence."}));
+        }
+    }
+
+    // Generate a secure random password (it will be temporary, user confirms & sets new one)
+    // Or, better: invite token that leads to password creation page.
+    // For now, sticking to creating user directly with placeholder password and confirmation.
+    let placeholder_password = rand::thread_rng()
+        .sample_iter(&rand::distributions::Alphanumeric)
+        .take(16)
+        .map(char::from)
+        .collect::<String>();
+
+    let salt = SaltString::generate(&mut rand::thread_rng());
+    let password_hash = match Argon2::default().hash_password(placeholder_password.as_bytes(), &salt) {
+        Ok(hash) => hash.to_string(),
+        Err(e) => {
+            log::error!("Failed to hash placeholder password for invite: {:?}", e);
+            return HttpResponse::InternalServerError().json(serde_json::json!({"error": "Failed to process invitation due to a security configuration issue."}));
+        }
+    };
+
+    let new_user_data = NewUser {
+        org_id: current_org_admin.org_id,
+        email: target_email.clone(),
+        password_hash,
+        role: "user".to_string(), // Org admins can only invite users with 'user' role to their org
+    };
+
+    match UserModel::create(&pool, new_user_data).await {
+        Ok(created_user) => {
+            let base_url = std::env::var("BASE_URL").unwrap_or_else(|_| "http://localhost:8080".into());
+            let confirmation_link = format!("{}/api/confirm/{}", base_url, created_user.confirmation_token.unwrap_or_default());
+
+            // Fetch organization name for email
+            let org_name = match sqlx::query_scalar::<_, String>("SELECT name FROM organizations WHERE id = $1")
+                .bind(current_org_admin.org_id)
+                .fetch_one(pool.as_ref())
+                .await {
+                    Ok(name) => name,
+                    Err(_) => "Your Organization".to_string(), // Fallback
+                };
+
+            let email_subject = format!("You're invited to join {} on crPipeline", org_name);
+            let email_body = format!(
+r#"Hello {},
+
+You have been invited by an administrator to join the organization '{}' on crPipeline.
+Please confirm your email address and set up your account by clicking the link below:
+{}
+
+If you were not expecting this invitation, you can safely ignore this email.
+
+Thank you,
+The crPipeline Team"#,
+                target_email, org_name, confirmation_link
+            );
+
+            if let Err(e) = send_email(&target_email, &email_subject, &email_body).await {
+                log::error!("User {} created by org_admin {}, but failed to send confirmation email to {}: {:?}", created_user.id, current_org_admin.user_id, target_email, e);
+                // User is created, but email failed. This is a partial success.
+                // The user will exist but won't be able to log in until confirmed.
+                // Global admin might need to intervene or resend confirmation.
+                return HttpResponse::Accepted().json(serde_json::json!({
+                    "success": true, // Technically user was created
+                    "message": "User account created, but the invitation email could not be sent. Please ask a global administrator to resend the confirmation or contact support.",
+                    "user_id": created_user.id
+                }));
+            }
+
+            log::info!("User {} invited to organization {} by org_admin {}. Email: {}", created_user.id, current_org_admin.org_id, current_org_admin.user_id, target_email);
+            HttpResponse::Ok().json(serde_json::json!({
+                "success": true,
+                "message": "Invitation sent successfully. The user needs to confirm their email address.",
+                "user_id": created_user.id
+            }))
+        }
+        Err(sqlx::Error::Database(db_err)) => {
+            // Check for unique constraint violation on email, though find_by_email should catch it.
+            // This is a fallback.
+            if db_err.constraint().map_or(false, |name| name.contains("users_email_key")) {
+                 HttpResponse::Conflict().json(serde_json::json!({"error": "This email address is already registered."}))
+            } else {
+                log::error!("Database error creating user for invite by org_admin {}: {:?}", current_org_admin.user_id, db_err);
+                HttpResponse::InternalServerError().json(serde_json::json!({"error": "Failed to create user account for invitation."}))
+            }
+        }
+        Err(e) => {
+            log::error!("Generic error creating user for invite by org_admin {}: {:?}", current_org_admin.user_id, e);
+            HttpResponse::InternalServerError().json(serde_json::json!({"error": "An unexpected error occurred during user invitation."}))
+        }
+    }
+}
+
+// --- Org Admin User Management Actions ---
+
+#[derive(Deserialize)]
+struct UserIdPath {
+    user_id: Uuid,
+}
+
+// Helper function to check if target user is in org_admin's org and is not the org_admin themselves
+async fn get_and_authorize_target_user_for_org_action(
+    pool: &PgPool,
+    org_admin_user_id: Uuid,
+    org_admin_org_id: Uuid,
+    target_user_id: Uuid,
+) -> Result<UserModel, HttpResponse> {
+    if target_user_id == org_admin_user_id {
+        return Err(HttpResponse::Forbidden().json(serde_json::json!({"error": "Organization administrators cannot manage their own account using this function."})));
+    }
+
+    match UserModel::find_by_id_for_admin(pool, target_user_id).await {
+        Ok(Some(target_user)) => {
+            if target_user.org_id != org_admin_org_id {
+                Err(HttpResponse::Forbidden().json(serde_json::json!({"error": "This user does not belong to your organization."})))
+            } else if target_user.role == "admin" || target_user.role == "org_admin" {
+                 Err(HttpResponse::Forbidden().json(serde_json::json!({"error": "Organization administrators cannot manage other administrators using this function."})))
+            }
+            else {
+                Ok(target_user)
+            }
+        }
+        Ok(None) => Err(HttpResponse::NotFound().json(serde_json::json!({"error": "Target user not found."}))),
+        Err(e) => {
+            log::error!("DB error fetching target user {} for org action by org_admin {}: {:?}", target_user_id, org_admin_user_id, e);
+            Err(HttpResponse::InternalServerError().json(serde_json::json!({"error": "Database error fetching user information."})))
+        }
+    }
+}
+
+async fn remove_user_from_organization(
+    org_admin: AuthUser,
+    path: web::Path<UserIdPath>,
+    pool: web::Data<PgPool>,
+) -> HttpResponse {
+    if org_admin.role != "org_admin" {
+        return HttpResponse::Forbidden().json(serde_json::json!({"error": "Only organization administrators can perform this action."}));
+    }
+    let target_user_id = path.user_id;
+
+    match get_and_authorize_target_user_for_org_action(&pool, org_admin.user_id, org_admin.org_id, target_user_id).await {
+        Ok(_target_user) => { // User is authorized and fetched
+            // Action: Deactivate the user
+            match sqlx::query("UPDATE users SET is_active = false, deactivated_at = NOW() WHERE id = $1 AND org_id = $2")
+                .bind(target_user_id)
+                .bind(org_admin.org_id) // Ensure still scoped to org
+                .execute(pool.as_ref())
+                .await
+            {
+                Ok(result) if result.rows_affected() > 0 => {
+                    log::info!("User {} removed (deactivated) from organization {} by org_admin {}", target_user_id, org_admin.org_id, org_admin.user_id);
+                    HttpResponse::Ok().json(serde_json::json!({"success": true, "message": "User has been removed (deactivated) from the organization."}))
+                }
+                Ok(_) => {
+                    log::warn!("User {} removal from org {} by org_admin {} had no effect (already deactivated or not found).", target_user_id, org_admin.org_id, org_admin.user_id);
+                    HttpResponse::Ok().json(serde_json::json!({"success": true, "message": "User was already in the requested state or not found during update."}))
+                }
+                Err(e) => {
+                    log::error!("Failed to deactivate user {} in org {} by org_admin {}: {:?}", target_user_id, org_admin.org_id, org_admin.user_id, e);
+                    HttpResponse::InternalServerError().json(serde_json::json!({"error": "Failed to update user status for removal."}))
+                }
+            }
+        }
+        Err(resp) => resp, // Return the error HttpResponse from the helper
+    }
+}
+
+async fn deactivate_user_in_organization(
+    org_admin: AuthUser,
+    path: web::Path<UserIdPath>,
+    pool: web::Data<PgPool>,
+) -> HttpResponse {
+     if org_admin.role != "org_admin" {
+        return HttpResponse::Forbidden().json(serde_json::json!({"error": "Only organization administrators can perform this action."}));
+    }
+    let target_user_id = path.user_id;
+    match get_and_authorize_target_user_for_org_action(&pool, org_admin.user_id, org_admin.org_id, target_user_id).await {
+        Ok(target_user) => {
+            if !target_user.is_active {
+                return HttpResponse::BadRequest().json(serde_json::json!({"error": "User is already deactivated."}));
+            }
+            match sqlx::query("UPDATE users SET is_active = false, deactivated_at = NOW() WHERE id = $1 AND org_id = $2")
+                .bind(target_user_id)
+                .bind(org_admin.org_id)
+                .execute(pool.as_ref())
+                .await
+            {
+                Ok(result) if result.rows_affected() > 0 => {
+                    log::info!("User {} deactivated in organization {} by org_admin {}", target_user_id, org_admin.org_id, org_admin.user_id);
+                    HttpResponse::Ok().json(serde_json::json!({"success": true, "message": "User deactivated successfully."}))
+                }
+                Ok(_) => HttpResponse::InternalServerError().json(serde_json::json!({"error": "Deactivation failed, user not found or no change."})), // Should be caught by get_and_authorize
+                Err(e) => {
+                    log::error!("Failed to deactivate user {} in org {} by org_admin {}: {:?}", target_user_id, org_admin.org_id, org_admin.user_id, e);
+                    HttpResponse::InternalServerError().json(serde_json::json!({"error": "Failed to deactivate user."}))
+                }
+            }
+        }
+        Err(resp) => resp,
+    }
+}
+
+async fn reactivate_user_in_organization(
+    org_admin: AuthUser,
+    path: web::Path<UserIdPath>,
+    pool: web::Data<PgPool>,
+) -> HttpResponse {
+    if org_admin.role != "org_admin" {
+        return HttpResponse::Forbidden().json(serde_json::json!({"error": "Only organization administrators can perform this action."}));
+    }
+    let target_user_id = path.user_id;
+     match get_and_authorize_target_user_for_org_action(&pool, org_admin.user_id, org_admin.org_id, target_user_id).await {
+        Ok(target_user) => {
+            if target_user.is_active {
+                return HttpResponse::BadRequest().json(serde_json::json!({"error": "User is already active."}));
+            }
+             match sqlx::query("UPDATE users SET is_active = true, deactivated_at = NULL WHERE id = $1 AND org_id = $2")
+                .bind(target_user_id)
+                .bind(org_admin.org_id)
+                .execute(pool.as_ref())
+                .await
+            {
+                Ok(result) if result.rows_affected() > 0 => {
+                    log::info!("User {} reactivated in organization {} by org_admin {}", target_user_id, org_admin.org_id, org_admin.user_id);
+                    HttpResponse::Ok().json(serde_json::json!({"success": true, "message": "User reactivated successfully."}))
+                }
+                Ok(_) => HttpResponse::InternalServerError().json(serde_json::json!({"error": "Reactivation failed, user not found or no change."})),
+                Err(e) => {
+                    log::error!("Failed to reactivate user {} in org {} by org_admin {}: {:?}", target_user_id, org_admin.org_id, org_admin.user_id, e);
+                    HttpResponse::InternalServerError().json(serde_json::json!({"error": "Failed to reactivate user."}))
+                }
+            }
+        }
+        Err(resp) => resp,
+    }
+}
+
+async fn resend_confirmation_email_org_user(
+    org_admin: AuthUser,
+    path: web::Path<UserIdPath>,
+    pool: web::Data<PgPool>,
+) -> HttpResponse {
+    if org_admin.role != "org_admin" {
+        return HttpResponse::Forbidden().json(serde_json::json!({"error": "Only organization administrators can perform this action."}));
+    }
+    let target_user_id = path.user_id;
+
+    match get_and_authorize_target_user_for_org_action(&pool, org_admin.user_id, org_admin.org_id, target_user_id).await {
+        Ok(target_user) => {
+            if target_user.confirmed {
+                return HttpResponse::BadRequest().json(serde_json::json!({"error": "User's email is already confirmed."}));
+            }
+
+            let new_confirmation_token = Uuid::new_v4();
+            // Update token and ensure user is marked as unconfirmed (should already be, but good practice)
+            match sqlx::query("UPDATE users SET confirmed = false, confirmation_token = $1 WHERE id = $2 AND org_id = $3")
+                .bind(new_confirmation_token)
+                .bind(target_user_id)
+                .bind(org_admin.org_id)
+                .execute(pool.as_ref())
+                .await
+            {
+                Ok(result) if result.rows_affected() > 0 => {
+                    let base_url = std::env::var("BASE_URL").unwrap_or_else(|_| "http://localhost:8080".into());
+                    let confirmation_link = format!("{}/api/confirm/{}", base_url, new_confirmation_token);
+
+                    let org_name = match sqlx::query_scalar::<_, String>("SELECT name FROM organizations WHERE id = $1")
+                        .bind(org_admin.org_id)
+                        .fetch_one(pool.as_ref())
+                        .await {
+                            Ok(name) => name,
+                            Err(_) => "Your Organization".to_string(),
+                        };
+
+                    let email_subject = format!("Confirm your email for {} on crPipeline", org_name);
+                    let email_body = format!(
+r#"Hello {},
+
+Please confirm your email address for the organization '{}' on crPipeline by clicking the link below:
+{}
+
+If you did not request this, please ignore this email.
+
+Thank you,
+The crPipeline Team"#,
+                        target_user.email, org_name, confirmation_link
+                    );
+
+                    if let Err(e) = send_email(&target_user.email, &email_subject, &email_body).await {
+                        log::error!("Failed to resend confirmation email to {} (user {}) by org_admin {}: {:?}", target_user.email, target_user_id, org_admin.user_id, e);
+                        HttpResponse::InternalServerError().json(serde_json::json!({"error": "Confirmation token updated, but failed to send email."}))
+                    } else {
+                        log::info!("Confirmation email resent to {} (user {}) by org_admin {}", target_user.email, target_user_id, org_admin.user_id);
+                        HttpResponse::Ok().json(serde_json::json!({"success": true, "message": "Confirmation email has been resent."}))
+                    }
+                }
+                Ok(_) => {
+                    log::warn!("Resend confirmation for user {} by org_admin {} had no effect (user not found or already confirmed).", target_user_id, org_admin.user_id);
+                    HttpResponse::NotFound().json(serde_json::json!({"error": "Failed to update confirmation token for user, or user already confirmed."}))
+                }
+                Err(e) => {
+                    log::error!("Database error updating confirmation token for user {} by org_admin {}: {:?}", target_user_id, org_admin.user_id, e);
+                    HttpResponse::InternalServerError().json(serde_json::json!({"error": "Database error while trying to resend confirmation."}))
+                }
+            }
+        }
+        Err(resp) => resp,
+    }
+}
+
+
+pub fn org_routes() -> Scope {
+    web::scope("/orgs")
+        .service(create_org)
+        .service(list_orgs)
+}
+
+pub fn org_me_routes() -> Scope {
+    web::scope("/organizations/me")
+        .route("/users", web::get().to(get_organization_users))
+        .route("/invite", web::post().to(invite_user_to_organization))
+        .route("/users/{user_id}/remove", web::post().to(remove_user_from_organization))
+        .route("/users/{user_id}/deactivate", web::post().to(deactivate_user_in_organization))
+        .route("/users/{user_id}/reactivate", web::post().to(reactivate_user_in_organization))
+        .route("/users/{user_id}/resend_confirmation", web::post().to(resend_confirmation_email_org_user))
+}
+
+// Main routes function to be called in main.rs or lib.rs
 pub fn routes(cfg: &mut web::ServiceConfig) {
-    cfg.service(create_org).service(list_orgs);
+    cfg.service(org_routes())
+       .service(org_me_routes());
 }

--- a/backend/tests/org_management_tests.rs
+++ b/backend/tests/org_management_tests.rs
@@ -1,0 +1,182 @@
+// backend/tests/org_management_tests.rs
+
+use actix_web::{test, web, App, http::header};
+use backend::handlers; // Assuming handlers::init configures all routes
+use backend::models::{User, Organization}; // For potential setup, though not fully implemented here
+use sqlx::PgPool;
+use uuid::Uuid;
+use serde_json::json;
+
+// Placeholder for a function that would set up the application with a test DB pool
+// and other necessary services, similar to main.rs.
+// This would ideally also handle migrations.
+async fn setup_test_app() -> (impl actix_web::dev::Service<actix_http::Request, Response = actix_web::dev::ServiceResponse, Error = actix_web::Error>, PgPool) {
+    dotenvy::dotenv().ok(); // Load .env for test specific vars if any (e.g. TEST_DATABASE_URL)
+
+    // IMPORTANT: This should connect to a TEST DATABASE, not the development or production one.
+    // Configuration for this is crucial and typically handled by environment variables.
+    let database_url = std::env::var("DATABASE_URL_TEST") // Example: Use a different env var for test DB
+        .unwrap_or_else(|_| std::env::var("DATABASE_URL").expect("DATABASE_URL must be set for tests if DATABASE_URL_TEST is not"));
+
+    let pool = PgPool::connect(&database_url)
+        .await
+        .expect("Failed to connect to test database");
+
+    // In a real test suite, you'd run migrations here.
+    // sqlx::migrate!("./migrations").run(&pool).await.expect("Failed to run migrations on test DB");
+
+    let app = test::init_service(
+        App::new()
+            .app_data(web::Data::new(pool.clone()))
+            // .app_data(web::Data::new(s3_client.clone())) // Add other app_data if needed by these handlers
+            .configure(handlers::init) // This should bring in your org routes
+    ).await;
+    (app, pool)
+}
+
+// Placeholder for JWT generation - in a real test suite, this would use a known test secret.
+fn generate_jwt_token(user_id: Uuid, org_id: Uuid, role: &str, org_name: &str) -> String {
+    // This is a very simplified placeholder.
+    // A real implementation would use the jsonwebtoken crate and a test signing secret.
+    // The actual token structure must match what your JWT validation middleware expects.
+    // Example claims (adjust to your actual JWT structure):
+    let claims = json!({
+        "exp": (chrono::Utc::now() + chrono::Duration::days(1)).timestamp(),
+        "iat": chrono::Utc::now().timestamp(),
+        "sub": user_id.to_string(),
+        "role": role,
+        "org_id": org_id.to_string(),
+        "org_name": org_name, // Assuming org_name is part of your AuthUser/token
+        "email": format!("{}@example.com", role), // Placeholder email
+        "confirmed": true,
+        "session_id": Uuid::new_v4().to_string() // Example session_id
+    });
+    // Sign the token with a TEST KEY (HS256 for simplicity here, match your app's algo)
+    // For now, returning a dummy string as the actual JWT logic is complex for this context.
+    // In a real test, you would use `jsonwebtoken::encode`.
+    // IMPORTANT: THIS IS NOT A REAL JWT AND WON'T PASS REAL AUTH.
+    format!("dummy-jwt-for-{}-{}-{}", user_id, org_id, role)
+}
+
+
+#[actix_rt::test]
+async fn test_get_organization_users_as_org_admin() {
+    let (app, pool) = setup_test_app().await;
+
+    // --- Test Data Setup (Conceptual - would be actual DB inserts) ---
+    let test_org_id = Uuid::new_v4();
+    let org_admin_id = Uuid::new_v4();
+    let user_in_org_id = Uuid::new_v4();
+    let test_org_name = "Test Org LLC";
+
+    // Imagine these users and the org are created in the test DB here.
+    // Example:
+    // sqlx::query("INSERT INTO organizations (id, name, api_key) VALUES ($1, $2, $3)")
+    //     .bind(test_org_id).bind(test_org_name).bind(Uuid::new_v4()).execute(&pool).await.unwrap();
+    // sqlx::query("INSERT INTO users (id, org_id, email, password_hash, role, confirmed, is_active) VALUES ($1, $2, $3, $4, $5, true, true)")
+    //     .bind(org_admin_id).bind(test_org_id).bind("orgadmin@example.com").bind("hashed_pass").bind("org_admin")
+    //     .execute(&pool).await.unwrap();
+    // sqlx::query("INSERT INTO users (id, org_id, email, password_hash, role, confirmed, is_active) VALUES ($1, $2, $3, $4, $5, true, true)")
+    //     .bind(user_in_org_id).bind(test_org_id).bind("user1@example.com").bind("hashed_pass").bind("user")
+    //     .execute(&pool).await.unwrap();
+    // --- End Test Data Setup ---
+
+    let token = generate_jwt_token(org_admin_id, test_org_id, "org_admin", test_org_name);
+
+    let req = test::TestRequest::get()
+        .uri("/api/organizations/me/users")
+        .insert_header((header::AUTHORIZATION, format!("Bearer {}", token)))
+        .to_request();
+
+    let resp = test::call_service(&app, req).await;
+    // println!("Response status: {:?}", resp.status());
+    // let body = test::read_body(resp).await;
+    // println!("Response body: {:?}", String::from_utf8_lossy(&body));
+
+    // For now, as the DB setup is conceptual, this test will likely fail or not return real data.
+    // A real test would assert on the actual users returned.
+    assert!(resp.status().is_success() || resp.status().is_client_error()); // Be lenient without DB
+
+    // Example assertions if data was present:
+    // assert!(resp.status().is_success());
+    // let users: Vec<serde_json::Value> = test::read_body_json(resp).await;
+    // assert_eq!(users.len(), 1); // Assuming one other user in the org
+    // assert_eq!(users[0]["email"], "user1@example.com");
+
+
+    // --- Cleanup (Conceptual - would delete test data) ---
+    // sqlx::query("DELETE FROM users WHERE org_id = $1").bind(test_org_id).execute(&pool).await.unwrap();
+    // sqlx::query("DELETE FROM organizations WHERE id = $1").bind(test_org_id).execute(&pool).await.unwrap();
+    // --- End Cleanup ---
+}
+
+#[actix_rt::test]
+async fn test_invite_user_to_organization_as_org_admin() {
+    let (app, pool) = setup_test_app().await;
+
+    let test_org_id = Uuid::new_v4();
+    let org_admin_id = Uuid::new_v4();
+    let test_org_name = "Invite Test Org";
+    let new_user_email = format!("invited_user_{}@example.com", Uuid::new_v4());
+
+    // --- Test Data Setup (Conceptual) ---
+    // Create org and org_admin user in DB
+    // --- End Test Data Setup ---
+
+    let token = generate_jwt_token(org_admin_id, test_org_id, "org_admin", test_org_name);
+
+    let payload = json!({ "email": new_user_email });
+
+    let req = test::TestRequest::post()
+        .uri("/api/organizations/me/invite")
+        .insert_header((header::AUTHORIZATION, format!("Bearer {}", token)))
+        // .insert_header((header::CONTENT_TYPE, "application/json")) // apiFetch usually sets this
+        // CSRF token would be needed here if middleware is active in test.
+        .set_json(&payload)
+        .to_request();
+
+    let resp = test::call_service(&app, req).await;
+    // println!("Invite Response status: {:?}", resp.status());
+    // let body = test::read_body(resp).await;
+    // println!("Invite Response body: {:?}", String::from_utf8_lossy(&body));
+
+    // Assert success or appropriate client error if prerequisites aren't fully met by conceptual setup
+    assert!(resp.status().is_success() || resp.status().is_client_error());
+
+    // Example assertions if successful:
+    // assert_eq!(resp.status(), actix_web::http::StatusCode::OK);
+    // let response_body: serde_json::Value = test::read_body_json(resp).await;
+    // assert_eq!(response_body["message"], "Invitation sent successfully. The user needs to confirm their email address.");
+    // let invited_user_id = Uuid::parse_str(response_body["user_id"].as_str().unwrap()).unwrap();
+
+    // Check DB for the new user, their org_id, role 'user', unconfirmed status, confirmation_token.
+    // Check that an email sending task would have been triggered (mock email service or check logs).
+
+    // --- Cleanup (Conceptual) ---
+    // --- End Cleanup ---
+}
+
+// TODO: Add more tests:
+// - test_get_organization_users_as_unauthorized_user (e.g. role 'user')
+// - test_invite_user_already_in_org
+// - test_invite_user_email_exists_in_other_org
+// - test_remove_user_from_organization_success
+// - test_remove_user_from_organization_target_is_admin_or_self (forbidden)
+// - test_deactivate_user_in_organization_success
+// - test_reactivate_user_in_organization_success
+// - test_resend_confirmation_email_org_user_success
+// - test_resend_confirmation_for_already_confirmed_user
+
+// Note: Full database setup, teardown, and real JWT/CSRF handling are crucial for robust tests.
+// The above uses conceptual placeholders for these aspects for brevity.
+// The `handlers::init` needs to correctly wire up all routes including those from `org.rs`.
+// If `s3_client` or other `app_data` is strictly required by the org handlers (even if not directly used),
+// it would need to be added in `setup_test_app`.
+// The actual JWT token generation in `generate_jwt_token` is a dummy and will not work
+// against the real JWT authentication middleware. It needs to be implemented correctly.
+// For CSRF, tests for POST/PUT/DELETE would need to handle the CSRF token.
+// One common strategy for CSRF in tests is to have a way to disable CSRF middleware during tests,
+// or to fetch a valid token from a dedicated endpoint first.
+// The DATABASE_URL_TEST environment variable is a placeholder for a real test database connection string.
+// Migrations must be run on the test database before tests execute.
+// Cleanup of created test data is important to keep tests idempotent.

--- a/frontend/src/lib/components/InviteUserModal.svelte
+++ b/frontend/src/lib/components/InviteUserModal.svelte
@@ -70,17 +70,25 @@
         return;
     }
 
-    const payload = {
-      email,
-      role: selectedRole,
-      org_id: selectedOrgId,
-    };
+    let apiPath: string;
+    let apiPayload: any;
+
+    if (isOrgAdminInvite) {
+      apiPath = `/api/organizations/me/invite`;
+      apiPayload = { email }; // Org admin invites implicitly set role='user' and use their own org_id
+    } else {
+      apiPath = `/api/admin/invite_user`;
+      apiPayload = {
+        email,
+        role: selectedRole,
+        org_id: selectedOrgId,
+      };
+    }
 
     try {
-      const response = await apiFetch(`/api/admin/invite_user`, { // Use apiFetch
+      const response = await apiFetch(apiPath, {
         method: 'POST',
-        // headers: { 'Content-Type': 'application/json' }, // apiFetch handles this
-        body: JSON.stringify(payload),
+        body: JSON.stringify(apiPayload),
       });
       const data = await response.json();
       if (!response.ok) {

--- a/frontend/src/lib/components/UserManagementView.svelte
+++ b/frontend/src/lib/components/UserManagementView.svelte
@@ -1,28 +1,27 @@
 <!-- frontend/src/lib/components/UserManagementView.svelte -->
 <script lang="ts">
   import { onMount } from 'svelte';
-  // import { page } from '$app/stores'; // Not used directly here, orgId/Name are props
   import DataTable, { type TableHeader } from '$lib/components/DataTable.svelte';
   import Button from '$lib/components/Button.svelte';
   import InviteUserModal from '$lib/components/InviteUserModal.svelte';
+  import ConfirmationModal from '$lib/components/ConfirmationModal.svelte'; // Import ConfirmationModal
   import { apiFetch } from '$lib/utils/apiUtils';
+  import { page } from '$app/stores'; // To get current user ID for self-action prevention
 
-  // Define Organization type, similar to OrgAdmin or a future shared types file
-  // For InviteUserModal, it primarily needs 'id' and 'name'.
   export interface Organization {
     id: string;
     name: string;
-    api_key?: string; // Optional as not always needed by InviteUserModal if just for display
+    api_key?: string;
   }
 
   interface OrgUserView {
     id: string;
     email: string;
-    role: string; // Should be 'user' for those managed by an OrgAdmin
+    role: string;
     confirmed: boolean;
     is_active: boolean;
     created_at: string;
-    deactivated_at?: string | null; // Included for completeness, though not displayed in a column
+    deactivated_at?: string | null;
   }
 
   export let orgId: string;
@@ -31,11 +30,26 @@
   let usersInOrg: OrgUserView[] = [];
   let isLoadingUsers: boolean = false;
   let errorLoadingUsers: string | null = null;
+  let generalError: string | null = null; // For general action errors
+  let generalSuccess: string | null = null; // For general action success messages
+
 
   let showInviteUserModal = false;
+  let currentOrgForInvite: Organization;
+  $: currentOrgForInvite = { id: orgId, name: orgName, api_key: '' };
 
-  let currentOrgForInvite: Organization; // For InviteUserModal, needs to match its expected type
-  $: currentOrgForInvite = { id: orgId, name: orgName, api_key: '' }; // api_key can be dummy
+  // Confirmation Modal State
+  let showConfirmationModal = false;
+  let confirmationTitle = '';
+  let confirmationMessage = '';
+  let confirmActionCallback: (() => Promise<void>) | null = null;
+  let confirmButtonText = 'Confirm';
+  type ButtonVariant = 'primary' | 'secondary' | 'danger' | 'ghost' | 'link';
+  let confirmButtonVariant: ButtonVariant = 'primary';
+  let selectedUserForAction: OrgUserView | null = null;
+
+  const currentUserId = $page.data.session?.userId;
+
 
   async function loadUsersInOrg() {
     if (!orgId) {
@@ -44,13 +58,13 @@
     }
     isLoadingUsers = true;
     errorLoadingUsers = null;
+    generalError = null; // Clear general errors on reload
+    generalSuccess = null; // Clear success messages
     try {
-      // This endpoint fetches users for the currently authenticated user's organization
-      // Ensure the backend correctly identifies the org admin and their org.
       const response = await apiFetch(`/api/organizations/me/users`);
       if (!response.ok) {
         const errText = await response.text();
-        const errData = JSON.parse(errText || "{}"); // Try to parse error
+        const errData = JSON.parse(errText || "{}");
         throw new Error(errData.error || `Failed to fetch users: ${response.statusText} - ${errText}`);
       }
       usersInOrg = await response.json();
@@ -73,6 +87,7 @@
     { key: 'status', label: 'Account Status', sortable: true },
     { key: 'confirmed', label: 'Email Confirmed', sortable: true },
     { key: 'created_at', label: 'Joined On', sortable: true, cellClass: '!text-gray-300' },
+    { key: 'actions', label: 'Actions', sortable: false, headerClass: 'text-right', cellClass: 'text-right !whitespace-nowrap' },
   ];
 
   function getAccountStatusClass(isActive: boolean): string {
@@ -80,6 +95,74 @@
   }
   function getConfirmationStatusClass(isConfirmed: boolean): string {
     return isConfirmed ? 'bg-success/20 text-success' : 'bg-error/20 text-error';
+  }
+
+  async function performUserAction(actionPath: string, successMessage: string, httpMethod: 'POST' | 'DELETE' = 'POST') {
+    generalError = null;
+    generalSuccess = null;
+    if (!selectedUserForAction) return;
+    try {
+      const response = await apiFetch(`/api/organizations/me/users/${selectedUserForAction.id}/${actionPath}`, { method: httpMethod });
+      const data = await response.json();
+      if (!response.ok) throw new Error(data.error || `Failed to ${actionPath} user.`);
+      generalSuccess = data.message || successMessage;
+      await loadUsersInOrg(); // Refresh list
+    } catch (e: any) {
+      generalError = e.message;
+      console.error(`Error during ${actionPath}:`, e);
+    } finally {
+      showConfirmationModal = false;
+      selectedUserForAction = null;
+    }
+  }
+
+  function requestRemoveUser(user: OrgUserView) {
+    selectedUserForAction = user;
+    confirmationTitle = 'Remove User from Organization';
+    confirmationMessage = `Are you sure you want to remove (deactivate) ${user.email} from ${orgName}? They will no longer be able to access this organization's resources.`;
+    confirmButtonText = 'Remove User';
+    confirmButtonVariant = 'danger';
+    confirmActionCallback = () => performUserAction('remove', 'User removed successfully.');
+    showConfirmationModal = true;
+  }
+
+  function requestDeactivateUser(user: OrgUserView) {
+    selectedUserForAction = user;
+    confirmationTitle = 'Deactivate User Account';
+    confirmationMessage = `Are you sure you want to deactivate ${user.email}? They will lose access until reactivated.`;
+    confirmButtonText = 'Deactivate';
+    confirmButtonVariant = 'danger';
+    confirmActionCallback = () => performUserAction('deactivate', 'User deactivated successfully.');
+    showConfirmationModal = true;
+  }
+
+  function requestReactivateUser(user: OrgUserView) {
+    selectedUserForAction = user;
+    confirmationTitle = 'Reactivate User Account';
+    confirmationMessage = `Are you sure you want to reactivate ${user.email}? They will regain access.`;
+    confirmButtonText = 'Reactivate';
+    confirmButtonVariant = 'primary';
+    confirmActionCallback = () => performUserAction('reactivate', 'User reactivated successfully.');
+    showConfirmationModal = true;
+  }
+
+  async function handleResendConfirmation(user: OrgUserView) {
+    generalError = null;
+    generalSuccess = null;
+    if (user.confirmed) {
+      generalError = "User's email is already confirmed.";
+      return;
+    }
+    try {
+      const response = await apiFetch(`/api/organizations/me/users/${user.id}/resend_confirmation`, { method: 'POST' });
+      const data = await response.json();
+      if (!response.ok) throw new Error(data.error || 'Failed to resend confirmation email.');
+      generalSuccess = data.message || 'Confirmation email resent successfully.';
+      // No need to reload users list as their status doesn't change immediately
+    } catch (e: any) {
+      generalError = e.message;
+      console.error("Error resending confirmation:", e);
+    }
   }
 
 </script>
@@ -95,6 +178,19 @@
     </Button>
   </div>
 
+  {#if generalError}
+    <div class="bg-error/20 border border-error/40 text-error px-4 py-3 rounded-lg my-4" role="alert">
+      <strong class="font-bold">Error:</strong>
+      <span class="block sm:inline ml-1">{generalError}</span>
+    </div>
+  {/if}
+  {#if generalSuccess}
+    <div class="bg-success/20 border border-success/40 text-success px-4 py-3 rounded-lg my-4" role="alert">
+      <strong class="font-bold">Success:</strong>
+      <span class="block sm:inline ml-1">{generalSuccess}</span>
+    </div>
+  {/if}
+
   {#if isLoadingUsers}
     <div class="flex justify-center items-center py-10">
       <div class="w-8 h-8 border-4 border-accent border-t-transparent rounded-full animate-spin"></div>
@@ -102,7 +198,7 @@
     </div>
   {:else if errorLoadingUsers}
     <div class="bg-error/10 border border-error/30 text-error px-4 py-3 rounded-lg" role="alert">
-      <strong class="font-bold">Error:</strong>
+      <strong class="font-bold">Error loading users:</strong>
       <span class="block sm:inline ml-1">{errorLoadingUsers}</span>
     </div>
   {:else}
@@ -139,6 +235,23 @@
          </span>
       </span>
       <span slot="cell-email" let:item title={item.email} class="block max-w-xs group-hover:text-accent-lighter transition-colors truncate">{item.email}</span>
+      <div slot="cell-actions" let:item class="flex justify-end items-center space-x-1">
+        {#if item.id === currentUserId}
+          <span class="text-xs text-gray-500 italic px-2 py-1">(Your Account)</span>
+        {:else if item.role === 'admin' || item.role === 'org_admin'}
+          <span class="text-xs text-gray-500 italic px-2 py-1">(Admin Role)</span>
+        {:else}
+          {#if item.is_active}
+            <Button variant="ghost" customClass="!px-1.5 !py-0.5 text-xs !text-orange-400 hover:!text-orange-300" on:click={() => requestDeactivateUser(item)} title="Deactivate User">Deactivate</Button>
+          {:else}
+            <Button variant="ghost" customClass="!px-1.5 !py-0.5 text-xs !text-green-400 hover:!text-green-300" on:click={() => requestReactivateUser(item)} title="Reactivate User">Reactivate</Button>,
+          {/if}
+          {#if !item.confirmed && item.is_active}
+            <Button variant="ghost" customClass="!px-1.5 !py-0.5 text-xs !text-sky-400 hover:!text-sky-300" on:click={() => handleResendConfirmation(item)} title="Resend Confirmation Email">Resend Email</Button>
+          {/if}
+          <Button variant="ghost" customClass="!px-1.5 !py-0.5 text-xs !text-red-500 hover:!text-red-400" on:click={() => requestRemoveUser(item)} title="Remove User from Organization">Remove</Button>
+        {/if}
+      </div>
     </DataTable>
   {/if}
 </div>
@@ -148,12 +261,26 @@
     isOpen={showInviteUserModal}
     organizations={[currentOrgForInvite]}
     isOrgAdminInvite={true}
-    defaultOrgId={orgId} {# Pass defaultOrgId explicitly #}
+    defaultOrgId={orgId}
     on:close={() => showInviteUserModal = false}
     on:user_invited={() => {
       showInviteUserModal = false;
       loadUsersInOrg();
+      generalSuccess = 'User invited successfully! They need to confirm their email.'; // Show success message
     }}
+  />
+{/if}
+
+{#if showConfirmationModal && confirmActionCallback}
+  <ConfirmationModal
+    isOpen={showConfirmationModal}
+    title={confirmationTitle}
+    message={confirmationMessage}
+    confirmText={confirmButtonText}
+    confirmButtonVariant={confirmButtonVariant}
+    on:confirm={() => { if (confirmActionCallback) confirmActionCallback(); }}
+    on:cancel={() => { showConfirmationModal = false; selectedUserForAction = null; }}
+    on:close={() => { showConfirmationModal = false; selectedUserForAction = null; }}
   />
 {/if}
 </html>


### PR DESCRIPTION
Phase 1 of enhancing admin capabilities:

Backend:
- Added GET /api/organizations/me/users endpoint for org admins to view users in their organization.
- Added POST /api/organizations/me/invite endpoint for org admins to invite new users (role 'user') to their organization.
- Added endpoints for org admins to manage users within their org:
  - POST /api/organizations/me/users/{user_id}/remove (deactivates user)
  - POST /api/organizations/me/users/{user_id}/deactivate
  - POST /api/organizations/me/users/{user_id}/reactivate
  - POST /api/organizations/me/users/{user_id}/resend_confirmation
- Refactored org routes for clarity.
- Enhanced authorization and error handling in org handlers.

Frontend:
- Updated InviteUserModal to use the new org-specific invite endpoint when an org admin is inviting.
- Updated UserManagementView to:
  - Display action buttons (Remove, Deactivate/Reactivate, Resend Confirmation) for users in the organization.
  - Integrate ConfirmationModal for destructive actions.
  - Call the new backend endpoints for these actions.
  - Prevent org admins from managing their own account or other admins via this view.
  - Provide user feedback messages for actions.

Testing:
- Created backend/tests/org_management_tests.rs with a structural outline and conceptual test cases for the new org admin API endpoints.
- Further work is needed to make these tests fully executable (DB seeding, real JWTs, CSRF handling).