### PR TITLE
Add backend tests to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,3 +27,5 @@ jobs:
         run: npm run build --prefix frontend # This can also serve as a test that the build passes
       - name: Check backend (Clippy) # Modified Step
         run: cargo clippy --manifest-path backend/Cargo.toml --all-targets -- --deny warnings
+      - name: Run backend tests
+        run: cargo test --manifest-path backend/Cargo.toml --all-targets


### PR DESCRIPTION
## Summary
- run backend tests in CI using `cargo test`

## Testing
- `cargo test --manifest-path backend/Cargo.toml --all-targets` *(fails: no matching package `jsonpath_rust`)*

------
https://chatgpt.com/codex/tasks/task_e_68603dff6b8c8333ba3430f3548799e0