### PR TITLE
Add GlobalLoadingIndicator component

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -2,7 +2,7 @@
 
 This document tracks remaining improvements and future work items identified across the codebase.
 
-- [ ] Create and integrate a reusable **GlobalLoadingIndicator** component.
+- [x] Create and integrate a reusable **GlobalLoadingIndicator** component.
 - [ ] Dispatch a global `pipelinesUpdated` event after saving pipelines so other pages can refresh automatically.
 - [ ] Update the pipelines list page to listen for the `pipelinesUpdated` event and refresh the list.
 - [ ] Show an error message in the Pipeline Editor UI when loading prompt templates fails.

--- a/frontend/src/lib/components/GlobalLoadingIndicator.svelte
+++ b/frontend/src/lib/components/GlobalLoadingIndicator.svelte
@@ -1,0 +1,9 @@
+<script lang="ts">
+  export let loading: boolean = false;
+</script>
+
+{#if loading}
+  <div class="fixed top-0 left-0 right-0 h-1 z-[200]" role="progressbar" aria-valuetext="loading">
+    <div class="h-full bg-accent animate-pulse rounded-r-full" style="width: 75%;"></div>
+  </div>
+{/if}

--- a/frontend/src/lib/components/__tests__/GlobalLoadingIndicator.test.ts
+++ b/frontend/src/lib/components/__tests__/GlobalLoadingIndicator.test.ts
@@ -1,0 +1,9 @@
+import { render } from '@testing-library/svelte';
+import GlobalLoadingIndicator from '../GlobalLoadingIndicator.svelte';
+import { expect, test } from 'vitest';
+
+test('renders progress bar when loading', () => {
+  const { getByRole } = render(GlobalLoadingIndicator, { props: { loading: true } });
+  expect(getByRole('progressbar')).toBeInTheDocument();
+});
+

--- a/frontend/src/routes/+layout.svelte
+++ b/frontend/src/routes/+layout.svelte
@@ -11,6 +11,7 @@
   import SlideOver from '$lib/components/SlideOver.svelte';
   import AnalysisJobDetail from '$lib/components/AnalysisJobDetail.svelte';
   import Button from '$lib/components/Button.svelte'; // For Dev Toggles
+  import GlobalLoadingIndicator from '$lib/components/GlobalLoadingIndicator.svelte';
 
   // Type Imports or Definitions
   export interface NavItem {
@@ -156,12 +157,7 @@
 
 </script>
 
-{#if globalLoading}
-  <!-- TODO: Create and import GlobalLoadingIndicator component -->
-  <div class="fixed top-0 left-0 right-0 h-1 z-[200]">
-    <div class="h-full bg-accent animate-pulse rounded-r-full" style="width: 75%;"></div>
-  </div>
-{/if}
+<GlobalLoadingIndicator loading={globalLoading} />
 
 <main class="min-h-screen flex bg-base text-gray-900 dark:bg-neutral-900 dark:text-gray-100">
   {#if loggedIn && org}


### PR DESCRIPTION
## Summary
- create `GlobalLoadingIndicator.svelte` component and basic test
- integrate indicator in the main layout
- mark the plan item as completed

## Testing
- `npm test --prefix frontend` *(fails: Invalid Chai property and other test failures)*
- `cargo test --manifest-path backend/Cargo.toml --all-targets` *(fails: no matching package `jsonpath_rust`)*

------
https://chatgpt.com/codex/tasks/task_e_68602475bd688333a9559736afd2f937