### PR TITLE
Add S3 cleanup logic

### DIFF
--- a/backend/Cargo.lock
+++ b/backend/Cargo.lock
@@ -35,6 +35,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "actix-csrf"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a090daa2a8b7aaaaf585f6a0dd0fbee92ea81728c01cc45ae7643d13e51dd4f"
+dependencies = [
+ "actix-web",
+ "base64 0.13.1",
+ "cookie",
+ "rand 0.8.5",
+ "serde",
+ "tracing",
+]
+
+[[package]]
 name = "actix-http"
 version = "3.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -932,6 +946,7 @@ name = "backend"
 version = "0.1.0"
 dependencies = [
  "actix-cors",
+ "actix-csrf",
  "actix-http-test",
  "actix-multipart",
  "actix-rt",
@@ -941,20 +956,26 @@ dependencies = [
  "actix-web-lab",
  "anyhow",
  "argon2",
+ "async-trait",
  "aws-config",
  "aws-sdk-s3",
+ "base64 0.21.7",
  "chrono",
  "dashmap",
  "dotenvy",
  "futures-util",
+ "jsonpath-rust",
  "jsonwebtoken",
  "lettre",
  "lopdf 0.32.0",
  "once_cell",
  "printpdf",
+ "pulldown-cmark",
  "rand 0.8.5",
  "redis",
+ "regex",
  "reqwest",
+ "sanitize-filename",
  "serde",
  "serde_json",
  "sqlx",
@@ -984,6 +1005,12 @@ name = "base-x"
 version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4cbbc9d0964165b47557570cce6c952866c2678457aca742aafc9fb771d30270"
+
+[[package]]
+name = "base64"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8"
 
 [[package]]
 name = "base64"
@@ -1788,6 +1815,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "getopts"
+version = "0.2.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cba6ae63eb948698e300f645f87c70f76630d505f23b8907cf1e193ee85048c1"
+dependencies = [
+ "unicode-width",
+]
+
+[[package]]
 name = "getrandom"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2230,6 +2266,19 @@ checksum = "1cfaf33c695fc6e08064efbc1f72ec937429614f25eef83af942d0e227c3a28f"
 dependencies = [
  "once_cell",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "jsonpath-rust"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b37465feaf9d41f74df7da98c6c1c31ca8ea06d11b5bf7869c8f1ccc51a793f"
+dependencies = [
+ "pest",
+ "pest_derive",
+ "regex",
+ "serde_json",
+ "thiserror 2.0.12",
 ]
 
 [[package]]
@@ -2729,6 +2778,50 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e"
 
 [[package]]
+name = "pest"
+version = "2.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1db05f56d34358a8b1066f67cbb203ee3e7ed2ba674a6263a1d5ec6db2204323"
+dependencies = [
+ "memchr",
+ "thiserror 2.0.12",
+ "ucd-trie",
+]
+
+[[package]]
+name = "pest_derive"
+version = "2.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb056d9e8ea77922845ec74a1c4e8fb17e7c218cc4fc11a15c5d25e189aa40bc"
+dependencies = [
+ "pest",
+ "pest_generator",
+]
+
+[[package]]
+name = "pest_generator"
+version = "2.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87e404e638f781eb3202dc82db6760c8ae8a1eeef7fb3fa8264b2ef280504966"
+dependencies = [
+ "pest",
+ "pest_meta",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.103",
+]
+
+[[package]]
+name = "pest_meta"
+version = "2.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edd1101f170f5903fde0914f899bb503d9ff5271d7ba76bbb70bea63690cc0d5"
+dependencies = [
+ "pest",
+ "sha2",
+]
+
+[[package]]
 name = "pin-project"
 version = "1.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2866,6 +2959,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6e944464ec8536cd1beb0bbfd96987eb5e3b72f2ecdafdc5c769a37f1fa2ae1f"
 dependencies = [
  "cc",
+]
+
+[[package]]
+name = "pulldown-cmark"
+version = "0.9.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57206b407293d2bcd3af849ce869d52068623f19e1b5ff8e8778e3309439682b"
+dependencies = [
+ "bitflags 2.9.1",
+ "getopts",
+ "memchr",
+ "unicase",
 ]
 
 [[package]]
@@ -3217,6 +3322,16 @@ name = "ryu"
 version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f"
+
+[[package]]
+name = "sanitize-filename"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a669999a88b3369d5dd9c7e31159b655a197d752bd42d47da6c930f2ad97ac9"
+dependencies = [
+ "lazy_static",
+ "regex",
+]
 
 [[package]]
 name = "schannel"
@@ -4200,6 +4315,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1dccffe3ce07af9386bfd29e80c0ab1a8205a2fc34e4bcd40364df902cfa8f3f"
 
 [[package]]
+name = "ucd-trie"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2896d95c02a80c6d6a5d6e953d479f5ddf2dfdb6a244441010e373ac0fb88971"
+
+[[package]]
+name = "unicase"
+version = "2.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75b844d17643ee918803943289730bec8aac480150456169e647ed0b576ba539"
+
+[[package]]
 name = "unicode-bidi"
 version = "0.3.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4231,6 +4358,12 @@ name = "unicode-segmentation"
 version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f6ccf251212114b54433ec949fd6a7841275f9ada20dddd2f29e9ceea4501493"
+
+[[package]]
+name = "unicode-width"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4a1a07cc7db3810833284e8d372ccdc6da29741639ecc70c9ec107df0fa6154c"
 
 [[package]]
 name = "unicode-xid"

--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -36,10 +36,11 @@ printpdf = "0.5"
 lettre = { version = "0.11", features = ["tokio1", "smtp-transport", "builder", "tokio1-native-tls"] }
 regex = "1" # Added for parse stage processing
 pulldown-cmark = "0.9" # For Markdown to PDF report generation
-jsonpath_rust = "0.2"  # For extracting summary fields in report stage
+jsonpath-rust = "1"  # For extracting summary fields in report stage
 sanitize-filename = "0.1" # For sanitizing original filenames for S3 keys
 actix-csrf = "0.6.0"      # For CSRF protection
 base64 = "0.21.0"         # For decoding CSRF secret key from .env
+async-trait = "0.1"
 
 [dev-dependencies]
 actix-http-test = "3"

--- a/backend/tests/cleanup.rs
+++ b/backend/tests/cleanup.rs
@@ -1,0 +1,36 @@
+use std::sync::{Arc, atomic::{AtomicUsize, Ordering}};
+use anyhow::{Error, anyhow};
+use async_trait::async_trait;
+use backend::handlers::document::{cleanup_s3_object, S3Deleter};
+
+#[derive(Clone, Default)]
+struct MockS3 {
+    calls: Arc<AtomicUsize>,
+    fail: bool,
+}
+
+#[async_trait]
+impl S3Deleter for MockS3 {
+    async fn delete_object(&self, _bucket: &str, _key: &str) -> Result<(), Error> {
+        self.calls.fetch_add(1, Ordering::SeqCst);
+        if self.fail {
+            Err(anyhow!("fail"))
+        } else {
+            Ok(())
+        }
+    }
+}
+
+#[actix_rt::test]
+async fn cleanup_invokes_delete() {
+    let mock = MockS3::default();
+    cleanup_s3_object(&mock, "b", "k").await;
+    assert_eq!(mock.calls.load(Ordering::SeqCst), 1);
+}
+
+#[actix_rt::test]
+async fn cleanup_logs_error() {
+    let mock = MockS3 { fail: true, ..Default::default() };
+    cleanup_s3_object(&mock, "b", "k").await;
+    assert_eq!(mock.calls.load(Ordering::SeqCst), 1);
+}


### PR DESCRIPTION
## Summary
- add helper trait `S3Deleter` and `cleanup_s3_object`
- call S3 cleanup when DB insert or quota check fails
- add unit tests for cleanup helper

## Testing
- `cargo test --no-run` *(fails: cannot compile `actix-csrf`)*

------
https://chatgpt.com/codex/tasks/task_e_68610630e344833380deb88785e4bf3e