### PR TITLE
Dispatch pipelinesUpdated event

### DIFF
--- a/README.md
+++ b/README.md
@@ -340,6 +340,15 @@ The frontend provides several key interfaces:
     - **AI Input/Output Side-by-Side:** A modal view to compare the JSON input sent to an AI stage and the JSON output it produced.
     - Lists all generated stage outputs with individual "Download" buttons (using pre-signed URLs) and "View (Modal)" buttons for text/JSON files.
 
+#### Frontend Events
+The Pipeline Editor dispatches a global `pipelinesUpdated` event on `document.body` after a successful save. Pages that list pipelines can listen for this event to refresh automatically:
+
+```ts
+document.body.addEventListener('pipelinesUpdated', () => {
+  // reload pipelines list
+});
+```
+
 ### Worker
 Run the background worker to process pending jobs:
 

--- a/frontend/src/lib/components/PipelineEditor.svelte
+++ b/frontend/src/lib/components/PipelineEditor.svelte
@@ -294,6 +294,8 @@
       if (response.ok) {
         alert('Pipeline saved successfully!');
         dispatch('saved'); // Notify parent to close the editor
+        // Emit global event so other pages can refresh pipeline lists
+        document.body.dispatchEvent(new CustomEvent('pipelinesUpdated'));
       } else {
         const errorData = await response.json().catch(() => ({ error: "Unknown error during save." }));
         console.error('Failed to save pipeline:', errorData);


### PR DESCRIPTION
## Summary
- trigger a `pipelinesUpdated` custom event when a pipeline is saved
- document the new event in the README

## Testing
- `npm test --prefix frontend` *(fails: Button and GlassCard tests)*
- `cargo test --manifest-path backend/Cargo.toml --no-run` *(fails to compile actix-csrf)*

------
https://chatgpt.com/codex/tasks/task_e_68610d8eb7ac8333a450c529a6c13dfb