### PR TITLE
Add org management integration tests

### DIFF
--- a/backend/tests/org_management_tests.rs
+++ b/backend/tests/org_management_tests.rs
@@ -1,9 +1,11 @@
 // backend/tests/org_management_tests.rs
 
 use actix_web::{test, web, App, http::header};
-use backend::handlers; // Assuming handlers::init configures all routes
-use backend::models::{User, Organization}; // For potential setup, though not fully implemented here
-use sqlx::PgPool;
+use backend::handlers;
+use backend::middleware::jwt::create_jwt;
+use sqlx::{PgPool, postgres::PgPoolOptions};
+use argon2::{Argon2, PasswordHasher};
+use argon2::password_hash::SaltString;
 use uuid::Uuid;
 use serde_json::json;
 
@@ -11,19 +13,21 @@ use serde_json::json;
 // and other necessary services, similar to main.rs.
 // This would ideally also handle migrations.
 async fn setup_test_app() -> (impl actix_web::dev::Service<actix_http::Request, Response = actix_web::dev::ServiceResponse, Error = actix_web::Error>, PgPool) {
-    dotenvy::dotenv().ok(); // Load .env for test specific vars if any (e.g. TEST_DATABASE_URL)
+    dotenvy::dotenv().ok();
 
-    // IMPORTANT: This should connect to a TEST DATABASE, not the development or production one.
-    // Configuration for this is crucial and typically handled by environment variables.
-    let database_url = std::env::var("DATABASE_URL_TEST") // Example: Use a different env var for test DB
-        .unwrap_or_else(|_| std::env::var("DATABASE_URL").expect("DATABASE_URL must be set for tests if DATABASE_URL_TEST is not"));
+    let database_url = std::env::var("DATABASE_URL_TEST")
+        .unwrap_or_else(|_| std::env::var("DATABASE_URL").expect("DATABASE_URL must be set"));
 
-    let pool = PgPool::connect(&database_url)
+    let pool = PgPoolOptions::new()
+        .max_connections(5)
+        .connect(&database_url)
         .await
         .expect("Failed to connect to test database");
 
-    // In a real test suite, you'd run migrations here.
-    // sqlx::migrate!("./migrations").run(&pool).await.expect("Failed to run migrations on test DB");
+    sqlx::migrate!("../migrations")
+        .run(&pool)
+        .await
+        .expect("Failed to run migrations on test DB");
 
     let app = test::init_service(
         App::new()
@@ -34,28 +38,44 @@ async fn setup_test_app() -> (impl actix_web::dev::Service<actix_http::Request, 
     (app, pool)
 }
 
-// Placeholder for JWT generation - in a real test suite, this would use a known test secret.
-fn generate_jwt_token(user_id: Uuid, org_id: Uuid, role: &str, org_name: &str) -> String {
-    // This is a very simplified placeholder.
-    // A real implementation would use the jsonwebtoken crate and a test signing secret.
-    // The actual token structure must match what your JWT validation middleware expects.
-    // Example claims (adjust to your actual JWT structure):
-    let claims = json!({
-        "exp": (chrono::Utc::now() + chrono::Duration::days(1)).timestamp(),
-        "iat": chrono::Utc::now().timestamp(),
-        "sub": user_id.to_string(),
-        "role": role,
-        "org_id": org_id.to_string(),
-        "org_name": org_name, // Assuming org_name is part of your AuthUser/token
-        "email": format!("{}@example.com", role), // Placeholder email
-        "confirmed": true,
-        "session_id": Uuid::new_v4().to_string() // Example session_id
-    });
-    // Sign the token with a TEST KEY (HS256 for simplicity here, match your app's algo)
-    // For now, returning a dummy string as the actual JWT logic is complex for this context.
-    // In a real test, you would use `jsonwebtoken::encode`.
-    // IMPORTANT: THIS IS NOT A REAL JWT AND WON'T PASS REAL AUTH.
-    format!("dummy-jwt-for-{}-{}-{}", user_id, org_id, role)
+fn generate_jwt_token(user_id: Uuid, org_id: Uuid, role: &str) -> String {
+    std::env::set_var("JWT_SECRET", "testsecret");
+    create_jwt(user_id, org_id, role)
+}
+
+async fn create_org(pool: &PgPool, name: &str) -> Uuid {
+    let org_id = Uuid::new_v4();
+    sqlx::query("INSERT INTO organizations (id, name, api_key) VALUES ($1, $2, uuid_generate_v4())")
+        .bind(org_id)
+        .bind(name)
+        .execute(pool)
+        .await
+        .unwrap();
+    sqlx::query("INSERT INTO org_settings (org_id) VALUES ($1)")
+        .bind(org_id)
+        .execute(pool)
+        .await
+        .unwrap();
+    org_id
+}
+
+async fn create_user(pool: &PgPool, org_id: Uuid, email: &str, role: &str) -> Uuid {
+    let user_id = Uuid::new_v4();
+    let salt = SaltString::generate(&mut rand::thread_rng());
+    let password_hash = Argon2::default()
+        .hash_password(b"password", &salt)
+        .unwrap()
+        .to_string();
+    sqlx::query("INSERT INTO users (id, org_id, email, password_hash, role, confirmed) VALUES ($1,$2,$3,$4,$5,true)")
+        .bind(user_id)
+        .bind(org_id)
+        .bind(email)
+        .bind(password_hash)
+        .bind(role)
+        .execute(pool)
+        .await
+        .unwrap();
+    user_id
 }
 
 
@@ -63,25 +83,12 @@ fn generate_jwt_token(user_id: Uuid, org_id: Uuid, role: &str, org_name: &str) -
 async fn test_get_organization_users_as_org_admin() {
     let (app, pool) = setup_test_app().await;
 
-    // --- Test Data Setup (Conceptual - would be actual DB inserts) ---
-    let test_org_id = Uuid::new_v4();
-    let org_admin_id = Uuid::new_v4();
-    let user_in_org_id = Uuid::new_v4();
-    let test_org_name = "Test Org LLC";
+    let org_id = create_org(&pool, "Test Org").await;
+    let admin_id = create_user(&pool, org_id, "admin@example.com", "org_admin").await;
+    let user_email = "user1@example.com";
+    let _user_id = create_user(&pool, org_id, user_email, "user").await;
 
-    // Imagine these users and the org are created in the test DB here.
-    // Example:
-    // sqlx::query("INSERT INTO organizations (id, name, api_key) VALUES ($1, $2, $3)")
-    //     .bind(test_org_id).bind(test_org_name).bind(Uuid::new_v4()).execute(&pool).await.unwrap();
-    // sqlx::query("INSERT INTO users (id, org_id, email, password_hash, role, confirmed, is_active) VALUES ($1, $2, $3, $4, $5, true, true)")
-    //     .bind(org_admin_id).bind(test_org_id).bind("orgadmin@example.com").bind("hashed_pass").bind("org_admin")
-    //     .execute(&pool).await.unwrap();
-    // sqlx::query("INSERT INTO users (id, org_id, email, password_hash, role, confirmed, is_active) VALUES ($1, $2, $3, $4, $5, true, true)")
-    //     .bind(user_in_org_id).bind(test_org_id).bind("user1@example.com").bind("hashed_pass").bind("user")
-    //     .execute(&pool).await.unwrap();
-    // --- End Test Data Setup ---
-
-    let token = generate_jwt_token(org_admin_id, test_org_id, "org_admin", test_org_name);
+    let token = generate_jwt_token(admin_id, org_id, "org_admin");
 
     let req = test::TestRequest::get()
         .uri("/api/organizations/me/users")
@@ -89,94 +96,98 @@ async fn test_get_organization_users_as_org_admin() {
         .to_request();
 
     let resp = test::call_service(&app, req).await;
-    // println!("Response status: {:?}", resp.status());
-    // let body = test::read_body(resp).await;
-    // println!("Response body: {:?}", String::from_utf8_lossy(&body));
+    assert!(resp.status().is_success());
 
-    // For now, as the DB setup is conceptual, this test will likely fail or not return real data.
-    // A real test would assert on the actual users returned.
-    assert!(resp.status().is_success() || resp.status().is_client_error()); // Be lenient without DB
-
-    // Example assertions if data was present:
-    // assert!(resp.status().is_success());
-    // let users: Vec<serde_json::Value> = test::read_body_json(resp).await;
-    // assert_eq!(users.len(), 1); // Assuming one other user in the org
-    // assert_eq!(users[0]["email"], "user1@example.com");
-
-
-    // --- Cleanup (Conceptual - would delete test data) ---
-    // sqlx::query("DELETE FROM users WHERE org_id = $1").bind(test_org_id).execute(&pool).await.unwrap();
-    // sqlx::query("DELETE FROM organizations WHERE id = $1").bind(test_org_id).execute(&pool).await.unwrap();
-    // --- End Cleanup ---
+    let users: Vec<serde_json::Value> = test::read_body_json(resp).await;
+    assert_eq!(users.len(), 2);
+    assert!(users.iter().any(|u| u["email"] == user_email));
 }
 
 #[actix_rt::test]
 async fn test_invite_user_to_organization_as_org_admin() {
     let (app, pool) = setup_test_app().await;
 
-    let test_org_id = Uuid::new_v4();
-    let org_admin_id = Uuid::new_v4();
-    let test_org_name = "Invite Test Org";
+    let org_id = create_org(&pool, "Invite Test Org").await;
+    let admin_id = create_user(&pool, org_id, "orgadmin@example.com", "org_admin").await;
+
+    let token = generate_jwt_token(admin_id, org_id, "org_admin");
+
     let new_user_email = format!("invited_user_{}@example.com", Uuid::new_v4());
-
-    // --- Test Data Setup (Conceptual) ---
-    // Create org and org_admin user in DB
-    // --- End Test Data Setup ---
-
-    let token = generate_jwt_token(org_admin_id, test_org_id, "org_admin", test_org_name);
-
     let payload = json!({ "email": new_user_email });
 
     let req = test::TestRequest::post()
         .uri("/api/organizations/me/invite")
         .insert_header((header::AUTHORIZATION, format!("Bearer {}", token)))
-        // .insert_header((header::CONTENT_TYPE, "application/json")) // apiFetch usually sets this
-        // CSRF token would be needed here if middleware is active in test.
         .set_json(&payload)
         .to_request();
 
     let resp = test::call_service(&app, req).await;
-    // println!("Invite Response status: {:?}", resp.status());
-    // let body = test::read_body(resp).await;
-    // println!("Invite Response body: {:?}", String::from_utf8_lossy(&body));
+    assert!(resp.status().is_success());
 
-    // Assert success or appropriate client error if prerequisites aren't fully met by conceptual setup
-    assert!(resp.status().is_success() || resp.status().is_client_error());
-
-    // Example assertions if successful:
-    // assert_eq!(resp.status(), actix_web::http::StatusCode::OK);
-    // let response_body: serde_json::Value = test::read_body_json(resp).await;
-    // assert_eq!(response_body["message"], "Invitation sent successfully. The user needs to confirm their email address.");
-    // let invited_user_id = Uuid::parse_str(response_body["user_id"].as_str().unwrap()).unwrap();
-
-    // Check DB for the new user, their org_id, role 'user', unconfirmed status, confirmation_token.
-    // Check that an email sending task would have been triggered (mock email service or check logs).
-
-    // --- Cleanup (Conceptual) ---
-    // --- End Cleanup ---
+    let count: (i64,) = sqlx::query_as("SELECT COUNT(*) FROM users WHERE email = $1")
+        .bind(&new_user_email)
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+    assert_eq!(count.0, 1);
 }
 
-// TODO: Add more tests:
-// - test_get_organization_users_as_unauthorized_user (e.g. role 'user')
-// - test_invite_user_already_in_org
-// - test_invite_user_email_exists_in_other_org
-// - test_remove_user_from_organization_success
-// - test_remove_user_from_organization_target_is_admin_or_self (forbidden)
-// - test_deactivate_user_in_organization_success
-// - test_reactivate_user_in_organization_success
-// - test_resend_confirmation_email_org_user_success
-// - test_resend_confirmation_for_already_confirmed_user
+#[actix_rt::test]
+async fn test_get_organization_users_as_unauthorized_user() {
+    let (app, pool) = setup_test_app().await;
 
-// Note: Full database setup, teardown, and real JWT/CSRF handling are crucial for robust tests.
-// The above uses conceptual placeholders for these aspects for brevity.
-// The `handlers::init` needs to correctly wire up all routes including those from `org.rs`.
-// If `s3_client` or other `app_data` is strictly required by the org handlers (even if not directly used),
-// it would need to be added in `setup_test_app`.
-// The actual JWT token generation in `generate_jwt_token` is a dummy and will not work
-// against the real JWT authentication middleware. It needs to be implemented correctly.
-// For CSRF, tests for POST/PUT/DELETE would need to handle the CSRF token.
-// One common strategy for CSRF in tests is to have a way to disable CSRF middleware during tests,
-// or to fetch a valid token from a dedicated endpoint first.
-// The DATABASE_URL_TEST environment variable is a placeholder for a real test database connection string.
-// Migrations must be run on the test database before tests execute.
-// Cleanup of created test data is important to keep tests idempotent.
+    let org_id = create_org(&pool, "Unauthorized Org").await;
+    let user_id = create_user(&pool, org_id, "user@example.com", "user").await;
+
+    let token = generate_jwt_token(user_id, org_id, "user");
+
+    let req = test::TestRequest::get()
+        .uri("/api/organizations/me/users")
+        .insert_header((header::AUTHORIZATION, format!("Bearer {}", token)))
+        .to_request();
+
+    let resp = test::call_service(&app, req).await;
+    assert_eq!(resp.status(), actix_web::http::StatusCode::FORBIDDEN);
+}
+
+#[actix_rt::test]
+async fn test_deactivate_and_reactivate_user() {
+    let (app, pool) = setup_test_app().await;
+
+    let org_id = create_org(&pool, "Deactivate Org").await;
+    let admin_id = create_user(&pool, org_id, "admin@example.com", "org_admin").await;
+    let user_id = create_user(&pool, org_id, "member@example.com", "user").await;
+
+    let token = generate_jwt_token(admin_id, org_id, "org_admin");
+
+    let req = test::TestRequest::post()
+        .uri(&format!("/api/organizations/me/users/{}/deactivate", user_id))
+        .insert_header((header::AUTHORIZATION, format!("Bearer {}", token.clone())))
+        .to_request();
+    let resp = test::call_service(&app, req).await;
+    assert!(resp.status().is_success());
+
+    let active: bool = sqlx::query_scalar("SELECT is_active FROM users WHERE id = $1")
+        .bind(user_id)
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+    assert!(!active);
+
+    let req = test::TestRequest::post()
+        .uri(&format!("/api/organizations/me/users/{}/reactivate", user_id))
+        .insert_header((header::AUTHORIZATION, format!("Bearer {}", token)))
+        .to_request();
+    let resp = test::call_service(&app, req).await;
+    assert!(resp.status().is_success());
+
+    let active: bool = sqlx::query_scalar("SELECT is_active FROM users WHERE id = $1")
+        .bind(user_id)
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+    assert!(active);
+}
+
+// These tests require a PostgreSQL instance pointed to by `DATABASE_URL_TEST`.
+// Migrations are applied automatically during setup.


### PR DESCRIPTION
## Summary
- add real cases for organization management tests
- set up test database with migrations
- implement JWT generation using middleware helper
- add tests for listing users, inviting users, unauthorized access, and account activation status changes

## Testing
- `cargo test --manifest-path backend/Cargo.toml` *(fails: could not compile `actix-csrf` due to missing `base64::encode_config`)*

------
https://chatgpt.com/codex/tasks/task_e_686128ea7d44833395530cd736517827