### PR TITLE
Add indexes for common lookups

### DIFF
--- a/backend/migrations/0002_processing/down.sql
+++ b/backend/migrations/0002_processing/down.sql
@@ -1,3 +1,7 @@
+-- Remove indexes added in the up migration
+DROP INDEX IF EXISTS idx_analysis_jobs_status;
+DROP INDEX IF EXISTS idx_documents_org_id;
+
 DROP TABLE IF EXISTS analysis_jobs;
 DROP TABLE IF EXISTS pipelines;
 DROP TABLE IF EXISTS documents;

--- a/backend/migrations/0002_processing/up.sql
+++ b/backend/migrations/0002_processing/up.sql
@@ -24,3 +24,7 @@ CREATE TABLE analysis_jobs (
   status TEXT NOT NULL,
   created_at TIMESTAMP WITH TIME ZONE DEFAULT NOW()
 );
+
+-- Indexes to speed up common lookups
+CREATE INDEX idx_documents_org_id ON documents(org_id);
+CREATE INDEX idx_analysis_jobs_status ON analysis_jobs(status);

--- a/backend/migrations/0009_create_job_stage_outputs/down.sql
+++ b/backend/migrations/0009_create_job_stage_outputs/down.sql
@@ -1,1 +1,4 @@
+-- Remove index created in the up migration
+DROP INDEX IF EXISTS idx_job_stage_outputs_job_id;
+
 DROP TABLE IF EXISTS job_stage_outputs;


### PR DESCRIPTION
## Summary
- add an org_id index on `documents`
- index `analysis_jobs` by status
- drop job_stage_outputs index on rollback

## Testing
- `cargo test` *(fails: cannot find function `encode_config` in crate `base64`)*
- `npm run build --silent --prefix frontend` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_686127346db483339cafc7a587d4891c