### PR TITLE
Remove unused CSRF support

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,14 +121,12 @@ SMTP_FROM=noreply@example.com
 BASE_URL=http://localhost:8080
 OCR_API_ENDPOINT=
 OCR_API_KEY=
-CSRF_SECRET_KEY_B64=
 ```
 
 `BASE_URL` is used when generating confirmation and reset links.
 `AWS_ENDPOINT` should be set to your MinIO or AWS S3 endpoint for development. In production, this variable can be removed to use AWS defaults if IAM roles are configured.
 `AI_API_URL` and `AI_API_KEY` serve as global defaults for the AI service if not overridden by more specific Organization Settings.
 `OCR_API_ENDPOINT` and `OCR_API_KEY` act as global defaults for an external OCR service. If these are not set, and no organization or stage-specific OCR settings are provided, the system falls back to local Tesseract OCR for "ocr" stages not using a custom command.
-`CSRF_SECRET_KEY_B64` holds a base64-encoded 32-byte key used by the CSRF middleware. Generate it with `scripts/generate_secrets.sh`.
 
 Organization-specific settings for AI (including custom headers) and OCR can override these global defaults. Pipeline stage definitions can further override OCR settings for specific "ocr" stages. See 'Settings' and 'Pipelines' sections for more details.
 

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -12,4 +12,3 @@ SMTP_USERNAME=your_username
 SMTP_PASSWORD=your_password
 SMTP_FROM=noreply@example.com
 BASE_URL=http://localhost:8080
-CSRF_SECRET_KEY_B64=

--- a/backend/Cargo.lock
+++ b/backend/Cargo.lock
@@ -34,19 +34,6 @@ dependencies = [
  "smallvec",
 ]
 
-[[package]]
-name = "actix-csrf"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d6604913d54205a3a5c0e43869a8e7501a2af7d7913b6653fd73f04ba292111"
-dependencies = [
- "actix-web",
- "base64 0.21.7",
- "cookie",
- "rand 0.8.5",
- "serde",
- "tracing",
-]
 
 [[package]]
 name = "actix-http"
@@ -946,7 +933,6 @@ name = "backend"
 version = "0.1.0"
 dependencies = [
  "actix-cors",
- "actix-csrf",
  "actix-http-test",
  "actix-multipart",
  "actix-rt",
@@ -959,7 +945,6 @@ dependencies = [
  "async-trait",
  "aws-config",
  "aws-sdk-s3",
- "base64 0.21.7",
  "chrono",
  "dashmap",
  "dotenvy",

--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -38,9 +38,7 @@ regex = "1" # Added for parse stage processing
 pulldown-cmark = "0.9" # For Markdown to PDF report generation
 jsonpath-rust = "1.0.2"  # For extracting summary fields in report stage
 sanitize-filename = "0.1" # For sanitizing original filenames for S3 keys
-actix-csrf = "0.8.0"      # For CSRF protection
 log = "0.4"
-base64 = "0.21.0"         # For decoding CSRF secret key from .env
 async-trait = "0.1"
 
 [features]

--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -26,7 +26,6 @@ async fn main() -> std::io::Result<()> {
     let shared_config = aws_config::from_env().region(region_provider).load().await;
     let s3_client = S3Client::new(&shared_config);
 
-    // Load CSRF Secret Key
     HttpServer::new(move || {
         let allowed_origin = env::var("FRONTEND_ORIGIN").unwrap_or_else(|_| "*".into());
         let cors = Cors::default()

--- a/frontend/src/lib/utils/apiUtils.ts
+++ b/frontend/src/lib/utils/apiUtils.ts
@@ -23,20 +23,6 @@ export interface FetchOptions extends RequestInit {
 export async function apiFetch(url: string, options: FetchOptions = {}): Promise<Response> {
   const headers = new Headers(options.headers || {});
 
-  // Add CSRF token for state-changing methods
-  const method = options.method?.toUpperCase() || 'GET';
-  if (['POST', 'PUT', 'DELETE', 'PATCH'].includes(method)) {
-    const token = getCookie('csrf-token'); // Default cookie name for actix-csrf
-    if (token) {
-      headers.set('X-CSRF-TOKEN', token); // Default header name for actix-csrf
-    } else {
-      // Only warn if not in SSR context, as document.cookie isn't available there.
-      // Backend GET requests (like for initial page load) will set the cookie.
-      if (typeof document !== 'undefined') {
-        console.warn('CSRF token cookie "csrf-token" not found. State-changing request might fail if this is a client-side navigation/action after initial load.');
-      }
-    }
-  }
 
   // Set Content-Type for JSON unless it's FormData or already set
   if (!options.isFormData && options.body && typeof options.body === 'string' && !headers.has('Content-Type')) {


### PR DESCRIPTION
## Summary
- drop actix-csrf and base64 deps
- remove CSRF_SECRET_KEY_B64 variable from docs and env example
- stop adding X-CSRF-TOKEN header in api utils

## Testing
- `cargo test --manifest-path backend/Cargo.toml` *(fails: cleanup_s3_object is private)*
- `npm install --prefix frontend`
- `npm run build --prefix frontend` *(fails: ParseError in App.svelte)*
- `npm test --prefix frontend` *(fails: 3 failing tests)*

------
https://chatgpt.com/codex/tasks/task_e_68613955a34483339e8a17f554674894