### PR TITLE
Update worker run command

### DIFF
--- a/README.md
+++ b/README.md
@@ -387,7 +387,7 @@ document.body.addEventListener('pipelinesUpdated', () => {
 Run the background worker to process pending jobs:
 
 ```bash
-cargo run --bin worker
+cargo run --bin worker --features worker-bin
 ```
 
 The worker pulls job IDs from Redis (set via `REDIS_URL`). For each job it executes the configured pipeline stages sequentially and updates the status in PostgreSQL.


### PR DESCRIPTION
## Summary
- update worker run instructions to gate with `worker-bin` feature

## Testing
- `cargo test` *(fails: could not compile `backend`)*

------
https://chatgpt.com/codex/tasks/task_e_686139537ea0833390a4fbe797525645