### PR TITLE
Add startup check for JWT_SECRET

### DIFF
--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -8,11 +8,12 @@ use aws_sdk_s3::Client as S3Client;
 
 
 use backend::handlers;
-use backend::middleware::rate_limit::RateLimit;
+use backend::middleware::{jwt::init_jwt_secret, rate_limit::RateLimit};
 
 #[actix_web::main]
 async fn main() -> std::io::Result<()> {
     dotenv().ok();
+    init_jwt_secret();
     tracing_subscriber::fmt::init(); // Or your existing logger
 
     let database_url = env::var("DATABASE_URL").expect("DATABASE_URL must be set");

--- a/backend/src/middleware/jwt.rs
+++ b/backend/src/middleware/jwt.rs
@@ -1,7 +1,20 @@
 use jsonwebtoken::{encode, Header, EncodingKey, decode, Validation, DecodingKey};
 use serde::{Serialize, Deserialize};
 use uuid::Uuid;
-use std::env;
+use std::{env, process};
+use once_cell::sync::Lazy;
+
+static JWT_SECRET: Lazy<String> = Lazy::new(|| {
+    env::var("JWT_SECRET").unwrap_or_else(|_| {
+        eprintln!("JWT_SECRET environment variable not set");
+        process::exit(1);
+    })
+});
+
+/// Ensure the JWT secret is loaded at startup.
+pub fn init_jwt_secret() {
+    Lazy::force(&JWT_SECRET);
+}
 
 #[derive(Serialize, Deserialize)]
 pub struct Claims {
@@ -12,7 +25,6 @@ pub struct Claims {
 }
 
 pub fn create_jwt(user_id: Uuid, org_id: Uuid, role: &str) -> String {
-    let secret = env::var("JWT_SECRET").unwrap_or_else(|_| "secret".into());
     let exp = chrono::Utc::now() + chrono::Duration::hours(24);
     let claims = Claims {
         sub: user_id,
@@ -20,12 +32,11 @@ pub fn create_jwt(user_id: Uuid, org_id: Uuid, role: &str) -> String {
         role: role.to_string(),
         exp: exp.timestamp() as usize,
     };
-    encode(&Header::default(), &claims, &EncodingKey::from_secret(secret.as_ref())).unwrap()
+    encode(&Header::default(), &claims, &EncodingKey::from_secret(JWT_SECRET.as_bytes())).unwrap()
 }
 
 pub fn verify_jwt(token: &str) -> Option<Claims> {
-    let secret = env::var("JWT_SECRET").unwrap_or_else(|_| "secret".into());
-    decode::<Claims>(token, &DecodingKey::from_secret(secret.as_ref()), &Validation::default())
+    decode::<Claims>(token, &DecodingKey::from_secret(JWT_SECRET.as_bytes()), &Validation::default())
         .map(|d| d.claims)
         .ok()
 }


### PR DESCRIPTION
## Summary
- load `JWT_SECRET` once and exit when missing
- initialize JWT secret in `main`

## Testing
- `cargo test --manifest-path backend/Cargo.toml --no-fail-fast` *(fails: could not compile `backend`)*

------
https://chatgpt.com/codex/tasks/task_e_6861463d43ec833381c95ee940816ab8