### PR TITLE
Remove unused CSRF env var

### DIFF
--- a/scripts/generate_secrets.sh
+++ b/scripts/generate_secrets.sh
@@ -8,7 +8,6 @@ JWT_SECRET=$(openssl rand -hex 32)
 AWS_ACCESS_KEY=${AWS_ACCESS_KEY:-$(openssl rand -hex 12)}
 AWS_SECRET_KEY=${AWS_SECRET_KEY:-$(openssl rand -hex 32)}
 REDIS_URL=${REDIS_URL:-redis://localhost/}
-CSRF_SECRET_KEY_B64=$(openssl rand -base64 32)
 
 cat > "$OUTPUT" <<EOT
 DATABASE_URL=
@@ -21,7 +20,6 @@ FRONTEND_ORIGIN=
 REDIS_URL=$REDIS_URL
 AI_API_URL=
 AI_API_KEY=
-CSRF_SECRET_KEY_B64=$CSRF_SECRET_KEY_B64
 EOT
 
 echo "Generated $OUTPUT with random credentials. Fill DATABASE_URL and other settings as needed."


### PR DESCRIPTION
## Summary
- clean up `generate_secrets.sh` by dropping the CSRF secret

## Testing
- `cargo test --manifest-path backend/Cargo.toml` *(fails: error canonicalizing migration directory)*
- `npm install --prefix frontend`
- `npm run build --prefix frontend` *(fails: Svelte parse error)*
- `npm test --prefix frontend` *(fails: some tests failed)*

------
https://chatgpt.com/codex/tasks/task_e_68614640bf6083338f187d4310c66695