### PR TITLE
Align OCR env var names

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ OCR_API_KEY=
 `BASE_URL` is used when generating confirmation and reset links.
 `AWS_ENDPOINT` should be set to your MinIO or AWS S3 endpoint for development. In production, this variable can be removed to use AWS defaults if IAM roles are configured.
 `AI_API_URL` and `AI_API_KEY` serve as global defaults for the AI service if not overridden by more specific Organization Settings.
-`OCR_API_ENDPOINT` and `OCR_API_KEY` act as global defaults for an external OCR service. If these are not set, and no organization or stage-specific OCR settings are provided, the system falls back to local Tesseract OCR for "ocr" stages not using a custom command.
+`OCR_API_ENDPOINT` and `OCR_API_KEY` act as global defaults for an external OCR service. If these are not set, and no organization or stage-specific OCR settings are provided, the system falls back to local Tesseract OCR for "ocr" stages not using a custom command. These names are used consistently across the worker and documentation.
 
 Organization-specific settings for AI (including custom headers) and OCR can override these global defaults. Pipeline stage definitions can further override OCR settings for specific "ocr" stages. See 'Settings' and 'Pipelines' sections for more details.
 

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -13,3 +13,10 @@ SMTP_USERNAME=your_username
 SMTP_PASSWORD=your_password
 SMTP_FROM=noreply@example.com
 BASE_URL=http://localhost:8080
+# Optional AI service defaults
+AI_API_URL=
+AI_API_KEY=
+
+# Optional global OCR service defaults
+OCR_API_ENDPOINT=
+OCR_API_KEY=

--- a/backend/src/bin/worker.rs
+++ b/backend/src/bin/worker.rs
@@ -271,11 +271,11 @@ async fn main() -> anyhow::Result<()> {
 
                     // 4. Global Environment Variable External OCR
                     if !ocr_method_determined_and_executed && !critical_ocr_failure {
-                        if let Ok(endpoint) = env::var("DEFAULT_EXTERNAL_OCR_ENDPOINT").filter(|s| !s.trim().is_empty()) {
+                        if let Ok(endpoint) = env::var("OCR_API_ENDPOINT").filter(|s| !s.trim().is_empty()) {
                             if stage.ocr_engine.as_deref() != Some("default") {
                                 tracing::debug!(job_id=%job.id, "OCR stage: Attempting GLOBAL ENV external OCR. Endpoint: {}", endpoint);
                                 ocr_method_determined_and_executed = true;
-                                let env_ocr_key = env::var("DEFAULT_EXTERNAL_OCR_API_KEY").ok();
+                                let env_ocr_key = env::var("OCR_API_KEY").ok();
                                 if let Err(_e) = execute_external_ocr(&endpoint, env_ocr_key.as_ref(), "Global Env").await {
                                     AnalysisJob::update_status(&pool, job.id, "failed").await?;
                                     if local.exists() { if let Err(e_c) = tokio::fs::remove_file(&local).await { tracing::error!(job_id=%job.id, "Cleanup error for input PDF: {:?}", e_c); }}

--- a/docs/Setup.md
+++ b/docs/Setup.md
@@ -23,6 +23,8 @@
 
 Environment variables can be tweaked in `backend/.env` to point to a different database or S3 endpoint. Ensure the bucket defined in `S3_BUCKET` exists in your MinIO or AWS account.
 
+The backend optionally supports an external OCR service. Set `OCR_API_ENDPOINT` and `OCR_API_KEY` in `backend/.env` to provide a global endpoint and API key used when no organization or stage-specific OCR configuration is present.
+
 ### Docker Compose
 All services can also be started via Docker for convenience:
 


### PR DESCRIPTION
## Summary
- standardize on `OCR_API_ENDPOINT`/`OCR_API_KEY`
- add example entries to `backend/.env.example`
- clarify usage in README and Setup docs
- adjust worker to read the new env vars

## Testing
- `cargo test --manifest-path backend/Cargo.toml` *(fails: error canonicalizing migration directory)*
- `npm test --prefix frontend` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686184e836348333b3ebbfaa74c6a17b