### PR TITLE
Add pipeline update and delete endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,7 +156,10 @@ Pipelines define the stages executed when a target document is uploaded. Use the
 ```
 POST /api/pipelines
 GET  /api/pipelines/{org_id}
+PUT    /api/pipelines/{id}
+DELETE /api/pipelines/{id}
 ```
+`PUT` and `DELETE` require an organization administrator (for their org) or a global admin.
 
 Uploading with `pipeline_id` will automatically create an `AnalysisJob` record.
 Only PDF files up to 200 MB are accepted. The server counts pages using a PDF parser before storing the file.

--- a/backend/src/models/pipeline.rs
+++ b/backend/src/models/pipeline.rs
@@ -26,4 +26,21 @@ impl Pipeline {
             .fetch_one(pool)
             .await
     }
+
+    pub async fn update(pool: &PgPool, id: Uuid, name: &str, stages: serde_json::Value) -> sqlx::Result<Pipeline> {
+        sqlx::query_as::<_, Pipeline>("UPDATE pipelines SET name=$1, stages=$2 WHERE id=$3 RETURNING *")
+            .bind(name)
+            .bind(stages)
+            .bind(id)
+            .fetch_one(pool)
+            .await
+    }
+
+    pub async fn delete(pool: &PgPool, id: Uuid) -> sqlx::Result<u64> {
+        let res = sqlx::query("DELETE FROM pipelines WHERE id=$1")
+            .bind(id)
+            .execute(pool)
+            .await?;
+        Ok(res.rows_affected())
+    }
 }


### PR DESCRIPTION
## Summary
- add Pipeline::update and ::delete helpers
- implement PUT and DELETE handlers for pipelines
- register new routes
- enable update/delete in PipelineEditor UI
- document new API endpoints in README

## Testing
- `cargo test` *(fails: error canonicalizing migration directory)*

------
https://chatgpt.com/codex/tasks/task_e_686186d43f8883338175de510a96a24f