### PR TITLE
Use apiFetch for pipeline operations

### DIFF
--- a/frontend/src/lib/components/PipelineEditor.svelte
+++ b/frontend/src/lib/components/PipelineEditor.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import Button from './Button.svelte';
   import { onMount, createEventDispatcher } from 'svelte'; // Import onMount and createEventDispatcher
+  import { apiFetch } from '$lib/utils/apiUtils';
 
   // Define Stage interface for clarity and new fields
   export interface Stage { // Exporting if it's useful for other components, otherwise keep local
@@ -71,7 +72,7 @@
     isLoadingOrgSettings = true;
     promptTemplatesError = null;
     try {
-      const response = await fetch(`/api/settings/${orgId}`);
+      const response = await apiFetch(`/api/settings/${orgId}`);
       if (!response.ok) {
         throw new Error(`Failed to fetch organization settings: ${response.statusText}`);
       }
@@ -284,12 +285,8 @@
     const method = isEdit ? 'PUT' : 'POST';
 
     try {
-      // Assuming apiFetch is available globally or imported
-      // For now, using standard fetch. If CSRF needed, replace with apiFetch
-      // import { apiFetch } from '$lib/utils/apiUtils'; // Needs to be at the top if used
-      const response = await fetch(url, {
+      const response = await apiFetch(url, {
         method: method,
-        headers: { 'Content-Type': 'application/json' }, // apiFetch would handle this
         body: JSON.stringify(finalPipelineData),
       });
 

--- a/frontend/src/lib/components/__tests__/PipelineEditor.test.ts
+++ b/frontend/src/lib/components/__tests__/PipelineEditor.test.ts
@@ -1,0 +1,27 @@
+import { render, fireEvent } from '@testing-library/svelte';
+import { vi, expect, test } from 'vitest';
+
+vi.mock('../../utils/apiUtils', () => ({
+  apiFetch: vi.fn(() => Promise.resolve({ ok: true, json: () => Promise.resolve({ prompt_templates: [] }) }))
+}));
+
+import { apiFetch } from '../../utils/apiUtils';
+import PipelineEditor from '../PipelineEditor.svelte';
+
+const initialPipeline = {
+  id: 'p1',
+  name: 'Test',
+  org_id: 'org1',
+  stages: [{ id: 's1', type: 'parse' }]
+};
+
+test('uses apiFetch for loading templates and saving pipeline', async () => {
+  const { getByText } = render(PipelineEditor, { props: { orgId: 'org1', initialPipeline } });
+
+  expect(apiFetch).toHaveBeenCalledWith('/api/settings/org1');
+
+  const saveBtn = getByText('Save');
+  await fireEvent.click(saveBtn);
+
+  expect(apiFetch).toHaveBeenCalledWith('/api/pipelines/p1', expect.objectContaining({ method: 'PUT' }));
+});


### PR DESCRIPTION
## Summary
- integrate apiFetch into PipelineEditor
- add test covering apiFetch usage

## Testing
- `npm test` *(fails: expected text content, spy called, style property)*

------
https://chatgpt.com/codex/tasks/task_e_68618b190b088333951ab1ec7158f2b1