### PR TITLE
Add rustfmt check to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,6 +17,8 @@ jobs:
         uses: actions/setup-rust@v1
         with:
           rust-version: stable
+      - name: Rustfmt
+        run: cargo fmt --manifest-path backend/Cargo.toml --all -- --check
       - name: Install frontend deps
         run: npm install --prefix frontend
       - name: Svelte Check

--- a/docs/Continuous_Integration.md
+++ b/docs/Continuous_Integration.md
@@ -3,6 +3,7 @@ A GitHub Actions workflow is provided at `.github/workflows/ci.yml`. On every pu
 
 - **Backend (Rust):**
   - `cargo clippy --manifest-path backend/Cargo.toml --all-targets -- --deny warnings`: Runs Clippy for thorough static analysis and treats all warnings as errors.
+  - `cargo fmt --manifest-path backend/Cargo.toml --all -- --check`: Ensures code is formatted according to `rustfmt` and fails the build on mismatches.
   - (Implicitly, `cargo test` would also be part of a full CI suite, though not explicitly listed as modified here).
 - **Frontend (Svelte/TypeScript):**
   - `npm install --prefix frontend`: Installs frontend dependencies.


### PR DESCRIPTION
## Summary
- run rustfmt in CI to enforce formatting
- document new rustfmt step

## Testing
- `cargo fmt --manifest-path backend/Cargo.toml --all -- --check` *(fails: 'cargo-fmt' not installed)*
- `cargo test --manifest-path backend/Cargo.toml --all-targets` *(fails: unresolved module and missing migrations)*
- `npm test --prefix frontend` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68618b1f5bb083338bad2feedd8c8110