### PR TITLE
Update test migration paths

### DIFF
--- a/backend/tests/admin_role_tests.rs
+++ b/backend/tests/admin_role_tests.rs
@@ -16,7 +16,7 @@ async fn setup_test_app() -> (impl actix_web::dev::Service<actix_http::Request, 
         .connect(&database_url)
         .await
         .expect("Failed to connect to test database");
-    sqlx::migrate!("../migrations")
+    sqlx::migrate!("migrations")
         .run(&pool)
         .await
         .expect("Failed to run migrations on test DB");

--- a/backend/tests/org_management_tests.rs
+++ b/backend/tests/org_management_tests.rs
@@ -24,7 +24,7 @@ async fn setup_test_app() -> (impl actix_web::dev::Service<actix_http::Request, 
         .await
         .expect("Failed to connect to test database");
 
-    sqlx::migrate!("../migrations")
+    sqlx::migrate!("migrations")
         .run(&pool)
         .await
         .expect("Failed to run migrations on test DB");

--- a/backend/tests/pipeline_tests.rs
+++ b/backend/tests/pipeline_tests.rs
@@ -17,7 +17,7 @@ async fn setup_test_app() -> (impl actix_web::dev::Service<actix_http::Request, 
         .connect(&database_url)
         .await
         .expect("Failed to connect to test database");
-    sqlx::migrate!("../migrations")
+    sqlx::migrate!("migrations")
         .run(&pool)
         .await
         .expect("Failed to run migrations on test DB");

--- a/backend/tests/worker_job.rs
+++ b/backend/tests/worker_job.rs
@@ -23,7 +23,7 @@ async fn worker_processes_job() {
         .connect("postgres://postgres@localhost/testdb")
         .await
         .unwrap();
-    sqlx::migrate!("../migrations").run(&pool).await.unwrap();
+    sqlx::migrate!("migrations").run(&pool).await.unwrap();
 
     // insert org, settings, user
     let org_id = Uuid::new_v4();


### PR DESCRIPTION
## Summary
- update SQL migration macros in tests

## Testing
- `cargo test --manifest-path backend/Cargo.toml` *(fails: paths relative to the current file's directory are not currently supported)*

------
https://chatgpt.com/codex/tasks/task_e_686190c98aa88333b1ada059bac2450c