### PR TITLE
Cleanup unused imports in backend

### DIFF
--- a/backend/src/middleware/rate_limit.rs
+++ b/backend/src/middleware/rate_limit.rs
@@ -7,9 +7,9 @@ use futures_util::future::{LocalBoxFuture, ready, Ready};
 use std::rc::Rc;
 use std::env;
 
-use crate::middleware::jwt::{verify_jwt, Claims}; // Assuming Claims is pub
+use crate::middleware::jwt::verify_jwt; // Assuming Claims is pub
 use redis::{AsyncCommands, Client as RedisClient};
-use actix_web::http::header::{AUTHORIZATION, COOKIE, HeaderName, HeaderValue};
+use actix_web::http::header::{AUTHORIZATION, HeaderName};
 use log::{error, warn}; // For logging
 use dashmap::DashMap;
 use once_cell::sync::Lazy;

--- a/backend/src/processing.rs
+++ b/backend/src/processing.rs
@@ -3,8 +3,7 @@ use std::fs::{File};
 use std::io::BufWriter;
 use aws_sdk_s3::Client as S3Client;
 use anyhow::{Result, anyhow, Context};
-use reqwest::Client;
-use reqwest::header::{HeaderMap, HeaderName, HeaderValue, AUTHORIZATION, CONTENT_TYPE};
+use reqwest::header::{HeaderName, HeaderValue, AUTHORIZATION, CONTENT_TYPE};
 use serde_json::Value as JsonValue; // For new parse stage
 use std::collections::HashMap; // For new parse stage
 use regex::Regex; // For new parse stage
@@ -13,8 +12,6 @@ use printpdf::*;
 use tokio::process::Command;
 use serde::Deserialize; // For CustomHeader
 use serde_json::Value; // For Value type hint
-use log; // For logging
-use uuid::Uuid;
 
 // For new report generation
 use pulldown_cmark::{Parser, Event, Tag, Options as MarkdownOptions, HeadingLevel};


### PR DESCRIPTION
## Summary
- remove unused imports from rate limiting middleware
- drop unused imports in processing helpers

## Testing
- `cargo clippy` *(fails: 'cargo-clippy' is not installed for the toolchain)*

------
https://chatgpt.com/codex/tasks/task_e_686190caa3988333a3e4c91604626b41