### PR TITLE
Document worker env vars

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,8 @@ SMTP_FROM=noreply@example.com
 BASE_URL=http://localhost:8080
 OCR_API_ENDPOINT=
 OCR_API_KEY=
+#PROCESS_ONE_JOB=1
+#LOCAL_S3_DIR=/tmp/s3
 ```
 
 `BASE_URL` is used when generating confirmation and reset links.
@@ -92,6 +94,8 @@ OCR_API_KEY=
 `OCR_API_ENDPOINT` and `OCR_API_KEY` act as global defaults for an external OCR service. If these are not set, and no organization or stage-specific OCR settings are provided, the system falls back to local Tesseract OCR for "ocr" stages not using a custom command. These names are used consistently across the worker and documentation.
 
 Organization-specific settings for AI (including custom headers) and OCR can override these global defaults. Pipeline stage definitions can further override OCR settings for specific "ocr" stages. See 'Settings' and 'Pipelines' sections for more details.
+
+`PROCESS_ONE_JOB` tells the worker to exit after handling a single job. `LOCAL_S3_DIR` lets the worker read and write files from the specified directory instead of S3, useful for local tests.
 
 ### Health check
 Verify the server is running with:

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -20,3 +20,5 @@ AI_API_KEY=
 # Optional global OCR service defaults
 OCR_API_ENDPOINT=
 OCR_API_KEY=
+#PROCESS_ONE_JOB=1
+#LOCAL_S3_DIR=/tmp/s3

--- a/docs/Setup.md
+++ b/docs/Setup.md
@@ -22,6 +22,7 @@
 6. The backend will be on `http://localhost:8080`, frontend on `http://localhost:5173`.
 
 Environment variables can be tweaked in `backend/.env` to point to a different database or S3 endpoint. Ensure the bucket defined in `S3_BUCKET` exists in your MinIO or AWS account.
+`PROCESS_ONE_JOB` makes the worker exit after a single job. Setting `LOCAL_S3_DIR` lets the worker store uploaded files under that path instead of S3, handy for local tests.
 
 The backend optionally supports an external OCR service. Set `OCR_API_ENDPOINT` and `OCR_API_KEY` in `backend/.env` to provide a global endpoint and API key used when no organization or stage-specific OCR configuration is present.
 


### PR DESCRIPTION
## Summary
- explain `PROCESS_ONE_JOB` and `LOCAL_S3_DIR` in Environment Variables section
- mention them in the setup guide
- add examples in `backend/.env.example`

## Testing
- `cargo test` *(fails: use of unresolved module or unlinked crate)*
- `npm install --prefix frontend`
- `npm test --prefix frontend` *(fails: tests and suite errors)*

------
https://chatgpt.com/codex/tasks/task_e_6861a260f9988333acf9870feba119e4