### PR TITLE
Improve CLI error handling

### DIFF
--- a/backend/src/bin/create_admin.rs
+++ b/backend/src/bin/create_admin.rs
@@ -5,9 +5,10 @@ use backend::models::{NewUser, User, Organization, NewOrganization, OrgSettings}
 use argon2::{Argon2, PasswordHasher};
 use argon2::password_hash::SaltString;
 use tracing::{info, error};
+use anyhow::Result;
 
 #[tokio::main]
-async fn main() -> Result<(), Box<dyn std::error::Error>> {
+async fn main() -> Result<()> {
     dotenv().ok();
     tracing_subscriber::fmt::init();
     let args: Vec<String> = std::env::args().collect();
@@ -20,7 +21,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let salt = SaltString::generate(&mut rand::thread_rng());
     let password_hash = Argon2::default()
         .hash_password(args[2].as_bytes(), &salt)
-        .unwrap()
+        .map_err(|e| anyhow::anyhow!("failed to hash password: {e}"))?
         .to_string();
     let org = sqlx::query_as::<_, Organization>("SELECT id, name, api_key FROM organizations LIMIT 1")
         .fetch_optional(&pool)

--- a/scripts/check_cli_errors.sh
+++ b/scripts/check_cli_errors.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+set -e
+cd "$(dirname "$0")/.."
+
+echo "Building CLI binaries..."
+cargo build --bins --manifest-path backend/Cargo.toml
+
+echo "Checking create_admin error output..."
+output=$(backend/target/debug/create_admin 2>&1 || true)
+if echo "$output" | grep -q "Usage: create_admin <email> <password>"; then
+  echo "create_admin error message OK"
+else
+  echo "Unexpected output from create_admin:" >&2
+  echo "$output" >&2
+  exit 1
+fi
+
+echo "Checking cleanup error output..."
+output=$(env -u DATABASE_URL backend/target/debug/cleanup 2>&1 || true)
+if echo "$output" | grep -q "environment variable"; then
+  echo "cleanup error message OK"
+else
+  echo "Unexpected output from cleanup:" >&2
+  echo "$output" >&2
+  exit 1
+fi
+
+echo "Manual CLI checks passed."


### PR DESCRIPTION
## Summary
- refactor `create_admin` to return `anyhow::Result`
- replace `unwrap()` when hashing the password with proper error handling
- add `scripts/check_cli_errors.sh` for manual CLI testing

## Testing
- `cargo check --bins --manifest-path backend/Cargo.toml`
- `bash scripts/check_cli_errors.sh`

------
https://chatgpt.com/codex/tasks/task_e_6861aa2a62a08333b8ab1e155ecd8e04