### PR TITLE
Add docs for handlers and worker modules

### DIFF
--- a/backend/src/bin/cleanup.rs
+++ b/backend/src/bin/cleanup.rs
@@ -6,6 +6,7 @@ use aws_sdk_s3::Client as S3Client;
 use backend::models::Document;
 use tracing::{info, error};
 
+/// Remove expired documents and their blobs from storage.
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
     dotenv().ok();

--- a/backend/src/bin/create_admin.rs
+++ b/backend/src/bin/create_admin.rs
@@ -6,6 +6,7 @@ use argon2::{Argon2, PasswordHasher};
 use argon2::password_hash::SaltString;
 use tracing::{info, error};
 
+/// Convenience utility to create an initial admin user.
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
     dotenv().ok();


### PR DESCRIPTION
## Summary
- document S3 deletion trait and cleanup helper
- describe upload params and endpoints for documents
- document job handlers for listing, events and details
- add explanations to worker binaries

## Testing
- `cargo test --quiet` *(fails: paths relative to current file's directory are not currently supported)*
- `cargo fmt --all` *(fails: 'cargo-fmt' is not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6861aa293b008333a18dffb34279c841