### PR TITLE
Fix Svelte template issues

### DIFF
--- a/frontend/src/App.svelte
+++ b/frontend/src/App.svelte
@@ -222,7 +222,7 @@
       <!-- Containers for components that are not main views but can be shown/hidden globally -->
       {#if showAdmin && org && role === 'admin'}
          <GlassCard title="Admin Panel" customClass="mt-6 text-left space-y-4" padding="p-4 md:p-6">
-            <OrgAdmin /> {/* Assuming OrgAdmin doesn't need role/orgId if App already gates it */}
+            <OrgAdmin />
          </GlassCard>
       {/if}
 
@@ -287,10 +287,10 @@
         <SettingsForm
           orgId={org}
           on:saved={(e) => {
-            settingsSaved(e); // Existing handler also closes panel
+            settingsSaved(e);
           }}
-          // No explicit on:cancel needed if SettingsForm doesn't have a dedicated cancel button
         />
+        <!-- No explicit on:cancel needed if SettingsForm doesn't have a dedicated cancel button -->
       {:else if showSettingsPanel && !org}
         <p class="text-red-500 p-4">Organization ID is not available. Cannot load settings.</p>
       {/if}

--- a/frontend/src/lib/components/DataTable.svelte
+++ b/frontend/src/lib/components/DataTable.svelte
@@ -1,20 +1,44 @@
-<script lang="ts">
-  // No $$props import needed for $$slots
-  import { createEventDispatcher, onMount, onDestroy } from 'svelte';
-  import { writable } from 'svelte/store';
-  // import type { ComponentProps } from 'svelte'; // For $$props if used for attributes
-  // import GlassCard from './GlassCard.svelte'; // Not used directly per row, container classes handle it
-
+<script context="module" lang="ts">
+  /** Table header definition exported for external consumption */
   export interface TableHeader {
     key: string;
     label: string;
     sortable?: boolean;
-    resizable?: boolean; // New: Default true, allow disabling resize per column
-    width?: number;      // New: Initial width in pixels (will be reactive)
-    minWidth?: number;   // New: Minimum width in pixels (e.g., 50)
+    resizable?: boolean; // allow disabling resize per column
+    width?: number;      // initial width in pixels
+    minWidth?: number;   // minimum width in pixels
     customClass?: string;
     headerClass?: string;
     cellClass?: string | ((value: any, item: any, rowIndex: number) => string);
+  }
+</script>
+
+<script lang="ts">
+  import { createEventDispatcher, onMount, onDestroy } from 'svelte';
+  import { writable } from 'svelte/store';
+
+  /** Slot typings for DataTable */
+  export interface $$Slots {
+    default: {};
+    ['cell-id']: { item: any; value: any; rowIndex: number };
+    ['cell-document_name']: { item: any; value: any; rowIndex: number };
+    ['cell-pipeline_name']: { item: any; value: any; rowIndex: number };
+    ['cell-status']: { item: any; value: any; rowIndex: number };
+    ['cell-created_at_formatted']: { item: any; value: any; rowIndex: number };
+    ['cell-actions']: { item: any; value: any; rowIndex: number };
+    ['cell-display_name']: { item: any; value: any; rowIndex: number };
+    ['cell-type']: { item: any; value: any; rowIndex: number };
+    ['cell-upload_date_formatted']: { item: any; value: any; rowIndex: number };
+    ['cell-name']: { item: any; value: any; rowIndex: number };
+    ['cell-stage_count']: { item: any; value: any; rowIndex: number };
+    ['cell-created_at']: { item: any; value: any; rowIndex: number };
+    ['cell-updated_at']: { item: any; value: any; rowIndex: number };
+    paginationControls?: {
+      currentPage: number;
+      totalPages: number;
+      itemsPerPage: number | null;
+      totalItems: number | null;
+    };
   }
 
   export let headers: TableHeader[] = [];
@@ -33,7 +57,6 @@
   // export let noDataMessage: string = "No data available."; // Removed old prop
   export let emptyStateMessage: string = "No data available.";
   export let emptyStateIconPath: string | null = null; // SVG path data
-  export let emptyStateSlotName: string = "emptyState"; // Slot name
 
   // Key function for #each block on items for Svelte reactivity
   export let keyField: string | null = 'id';
@@ -246,8 +269,8 @@
       {#if sortedItems.length === 0}
         <tr>
           <td colspan={headers.length} class="px-6 py-12 text-center">
-            {#if $$slots[emptyStateSlotName]}
-              <slot name={emptyStateSlotName}></slot>
+            {#if $$slots.emptyState}
+              <slot name="emptyState"></slot>
             {:else}
               <div class="flex flex-col items-center justify-center space-y-3 text-gray-400">
                 {#if emptyStateIconPath}
@@ -265,8 +288,32 @@
           <tr class="{trClass}">
             {#each headers as header (header.key)}
               <td class="{tdClass} {resolveCellClass(header, item, item[header.key], rowIndex)}" style={getColumnStyle(header.key)}>
-                {#if $$slots[`cell-${header.key}`]}
-                  <slot name={`cell-${header.key}`} {item} value={item[header.key]} {rowIndex}></slot>
+                {#if header.key === 'id' && $$slots['cell-id']}
+                  <slot name="cell-id" {item} value={item[header.key]} {rowIndex}></slot>
+                {:else if header.key === 'document_name' && $$slots['cell-document_name']}
+                  <slot name="cell-document_name" {item} value={item[header.key]} {rowIndex}></slot>
+                {:else if header.key === 'pipeline_name' && $$slots['cell-pipeline_name']}
+                  <slot name="cell-pipeline_name" {item} value={item[header.key]} {rowIndex}></slot>
+                {:else if header.key === 'status' && $$slots['cell-status']}
+                  <slot name="cell-status" {item} value={item[header.key]} {rowIndex}></slot>
+                {:else if header.key === 'created_at_formatted' && $$slots['cell-created_at_formatted']}
+                  <slot name="cell-created_at_formatted" {item} value={item[header.key]} {rowIndex}></slot>
+                {:else if header.key === 'actions' && $$slots['cell-actions']}
+                  <slot name="cell-actions" {item} value={item[header.key]} {rowIndex}></slot>
+                {:else if header.key === 'display_name' && $$slots['cell-display_name']}
+                  <slot name="cell-display_name" {item} value={item[header.key]} {rowIndex}></slot>
+                {:else if header.key === 'type' && $$slots['cell-type']}
+                  <slot name="cell-type" {item} value={item[header.key]} {rowIndex}></slot>
+                {:else if header.key === 'upload_date_formatted' && $$slots['cell-upload_date_formatted']}
+                  <slot name="cell-upload_date_formatted" {item} value={item[header.key]} {rowIndex}></slot>
+                {:else if header.key === 'name' && $$slots['cell-name']}
+                  <slot name="cell-name" {item} value={item[header.key]} {rowIndex}></slot>
+                {:else if header.key === 'stage_count' && $$slots['cell-stage_count']}
+                  <slot name="cell-stage_count" {item} value={item[header.key]} {rowIndex}></slot>
+                {:else if header.key === 'created_at' && $$slots['cell-created_at']}
+                  <slot name="cell-created_at" {item} value={item[header.key]} {rowIndex}></slot>
+                {:else if header.key === 'updated_at' && $$slots['cell-updated_at']}
+                  <slot name="cell-updated_at" {item} value={item[header.key]} {rowIndex}></slot>
                 {:else}
                   {item[header.key] === null || item[header.key] === undefined ? '' : item[header.key]}
                 {/if}

--- a/frontend/src/lib/components/PipelineEditor.svelte
+++ b/frontend/src/lib/components/PipelineEditor.svelte
@@ -480,9 +480,13 @@
   <div class="space-y-3">
     {#each pipeline.stages as stage, i (stage.id)}
       <div
-        class="stage-item p-4 rounded-lg cursor-grab border-2"
-               {draggingVisualIndex === i ? 'dragging !border-accent' : 'border-neutral-700/70'}
-               {draggedOverIndex === i && draggedItemId !== stage.id ? 'drag-over-highlight !border-accent' : 'hover:border-neutral-600'}"
+        class={`stage-item p-4 rounded-lg cursor-grab border-2 ${
+          draggingVisualIndex === i ? 'dragging !border-accent' : 'border-neutral-700/70'
+        } ${
+          draggedOverIndex === i && draggedItemId !== stage.id
+            ? 'drag-over-highlight !border-accent'
+            : 'hover:border-neutral-600'
+        }`}
         draggable="true"
         on:dragstart={(event) => handleDragStart(event, stage.id, i)}
         on:dragover={(event) => handleDragOver(event, i)}

--- a/frontend/src/routes/pipelines/+page.svelte
+++ b/frontend/src/routes/pipelines/+page.svelte
@@ -196,9 +196,8 @@
             <span slot="cell-name" let:item title={item.name} class="block truncate max-w-md group-hover:text-accent-lighter transition-colors">
                 {item.name}
             </span>
-            <!-- @ts-ignore -->
-            <span slot="cell-created_at" let:item:Pipeline class="text-xs text-gray-400">{item.created_at}</span>
-            <span slot="cell-updated_at" let:item:Pipeline class="text-xs text-gray-400">{item.updated_at}</span>
+            <span slot="cell-created_at" let:item class="text-xs text-gray-400">{item.created_at}</span>
+            <span slot="cell-updated_at" let:item class="text-xs text-gray-400">{item.updated_at}</span>
         </DataTable>
     {/if}
 </div>


### PR DESCRIPTION
## Summary
- remove React style comments and invalid syntax in `App.svelte`
- repair class attribute in `PipelineEditor.svelte`
- define slot typings for `DataTable.svelte`
- cleanup slot usage in pipelines page

## Testing
- `npm run lint --prefix frontend` *(fails: svelte-check found 52 errors)*
- `npm run build --prefix frontend` *(fails to compile)*

------
https://chatgpt.com/codex/tasks/task_e_6861b3fdaa988333a849871abfb31d1d