### PR TITLE
Add href support to Button

### DIFF
--- a/frontend/src/lib/components/Button.svelte
+++ b/frontend/src/lib/components/Button.svelte
@@ -3,6 +3,7 @@
   export let type: 'button' | 'submit' | 'reset' = 'button';
   export let disabled: boolean = false;
   export let customClass: string = ''; // Renamed from 'class' to avoid conflict if used directly
+  export let href: string | undefined = undefined;
 
   let baseClasses: string =
     "px-4 py-2 rounded-lg font-semibold focus:outline-none focus:ring-2 focus:ring-offset-2 \
@@ -39,14 +40,25 @@
   }
 </script>
 
-<button
-  type={type}
-  class="{baseClasses} {currentVariantClasses} {customClass}"
-  {disabled}
-  on:click
->
-  <slot />
-</button>
+{#if href}
+  <a
+    href={href}
+    class="{baseClasses} {currentVariantClasses} {customClass}"
+    aria-disabled={disabled}
+    on:click
+  >
+    <slot />
+  </a>
+{:else}
+  <button
+    type={type}
+    class="{baseClasses} {currentVariantClasses} {customClass}"
+    {disabled}
+    on:click
+  >
+    <slot />
+  </button>
+{/if}
 
 <style lang="postcss">
   /* Ensure --color-accent is available globally for bg-accent to work */

--- a/frontend/src/lib/components/Button.test.ts
+++ b/frontend/src/lib/components/Button.test.ts
@@ -98,4 +98,11 @@ describe('Button.svelte', () => {
     expect(button.classList.contains('my-custom-class')).toBe(true);
     expect(button.classList.contains('another-class')).toBe(true);
   });
+
+  it('renders an anchor when href is provided', () => {
+    render(Button, { props: { href: '/test', slot: 'Link Button' } });
+    const link = screen.getByRole('link');
+    expect(link).toHaveAttribute('href', '/test');
+    expect(link).toHaveTextContent('Link Button');
+  });
 });


### PR DESCRIPTION
## Summary
- make Button optionally render as a link when `href` is provided
- cover new link behaviour in unit tests

## Testing
- `npm test --prefix frontend` *(fails: no tests executed)*
- `cargo test --manifest-path backend/Cargo.toml --all-targets` *(fails: DATABASE_URL must be set)*

------
https://chatgpt.com/codex/tasks/task_e_6861be4694c0833392cfb75411d9184d