### PR TITLE
Introduce shared test utilities

### DIFF
--- a/backend/tests/admin_role_tests.rs
+++ b/backend/tests/admin_role_tests.rs
@@ -1,72 +1,10 @@
-use actix_web::{test, web, App, http::header};
+use actix_web::{test, http::header};
 use backend::handlers;
-use backend::middleware::jwt::create_jwt;
-use sqlx::{PgPool, postgres::PgPoolOptions};
-use argon2::{Argon2, PasswordHasher};
-use argon2::password_hash::SaltString;
 use uuid::Uuid;
 use serde_json::json;
 
-async fn setup_test_app() -> (impl actix_web::dev::Service<actix_http::Request, Response = actix_web::dev::ServiceResponse, Error = actix_web::Error>, PgPool) {
-    dotenvy::dotenv().ok();
-    let database_url = std::env::var("DATABASE_URL_TEST")
-        .unwrap_or_else(|_| std::env::var("DATABASE_URL").expect("DATABASE_URL must be set"));
-    let pool = PgPoolOptions::new()
-        .max_connections(5)
-        .connect(&database_url)
-        .await
-        .expect("Failed to connect to test database");
-    sqlx::migrate!("./migrations")
-        .run(&pool)
-        .await
-        .expect("Failed to run migrations on test DB");
-    let app = test::init_service(
-        App::new()
-            .app_data(web::Data::new(pool.clone()))
-            .configure(handlers::init)
-    ).await;
-    (app, pool)
-}
-
-fn generate_jwt_token(user_id: Uuid, org_id: Uuid, role: &str) -> String {
-    std::env::set_var("JWT_SECRET", "testsecret");
-    create_jwt(user_id, org_id, role)
-}
-
-async fn create_org(pool: &PgPool, name: &str) -> Uuid {
-    let org_id = Uuid::new_v4();
-    sqlx::query("INSERT INTO organizations (id, name, api_key) VALUES ($1, $2, uuid_generate_v4())")
-        .bind(org_id)
-        .bind(name)
-        .execute(pool)
-        .await
-        .unwrap();
-    sqlx::query("INSERT INTO org_settings (org_id) VALUES ($1)")
-        .bind(org_id)
-        .execute(pool)
-        .await
-        .unwrap();
-    org_id
-}
-
-async fn create_user(pool: &PgPool, org_id: Uuid, email: &str, role: &str) -> Uuid {
-    let user_id = Uuid::new_v4();
-    let salt = SaltString::generate(&mut rand::thread_rng());
-    let password_hash = Argon2::default()
-        .hash_password(b"password", &salt)
-        .unwrap()
-        .to_string();
-    sqlx::query("INSERT INTO users (id, org_id, email, password_hash, role, confirmed) VALUES ($1,$2,$3,$4,$5,true)")
-        .bind(user_id)
-        .bind(org_id)
-        .bind(email)
-        .bind(password_hash)
-        .bind(role)
-        .execute(pool)
-        .await
-        .unwrap();
-    user_id
-}
+mod test_utils;
+use test_utils::{setup_test_app, create_org, create_user, generate_jwt_token};
 
 #[actix_rt::test]
 async fn test_global_admin_assign_role_success() {

--- a/backend/tests/document_tests.rs
+++ b/backend/tests/document_tests.rs
@@ -1,11 +1,11 @@
 use actix_web::{test, web, App, http::header};
 use backend::handlers;
-use backend::middleware::jwt::create_jwt;
 use sqlx::{PgPool, postgres::PgPoolOptions};
-use argon2::{Argon2, PasswordHasher};
-use argon2::password_hash::SaltString;
 use uuid::Uuid;
 use serde_json::json;
+
+mod test_utils;
+use test_utils::{create_org, create_user, generate_jwt_token};
 use wiremock::{MockServer, Mock, ResponseTemplate};
 use wiremock::matchers::method;
 use aws_config::meta::region::RegionProviderChain;
@@ -44,45 +44,6 @@ async fn setup_test_app(s3_server: &MockServer) -> (impl actix_web::dev::Service
     (app, pool)
 }
 
-fn generate_jwt_token(user_id: Uuid, org_id: Uuid, role: &str) -> String {
-    std::env::set_var("JWT_SECRET", "testsecret");
-    create_jwt(user_id, org_id, role)
-}
-
-async fn create_org(pool: &PgPool, name: &str) -> Uuid {
-    let org_id = Uuid::new_v4();
-    sqlx::query("INSERT INTO organizations (id, name, api_key) VALUES ($1, $2, uuid_generate_v4())")
-        .bind(org_id)
-        .bind(name)
-        .execute(pool)
-        .await
-        .unwrap();
-    sqlx::query("INSERT INTO org_settings (org_id) VALUES ($1)")
-        .bind(org_id)
-        .execute(pool)
-        .await
-        .unwrap();
-    org_id
-}
-
-async fn create_user(pool: &PgPool, org_id: Uuid, email: &str, role: &str) -> Uuid {
-    let user_id = Uuid::new_v4();
-    let salt = SaltString::generate(&mut rand::thread_rng());
-    let password_hash = Argon2::default()
-        .hash_password(b"password", &salt)
-        .unwrap()
-        .to_string();
-    sqlx::query("INSERT INTO users (id, org_id, email, password_hash, role, confirmed) VALUES ($1,$2,$3,$4,$5,true)")
-        .bind(user_id)
-        .bind(org_id)
-        .bind(email)
-        .bind(password_hash)
-        .bind(role)
-        .execute(pool)
-        .await
-        .unwrap();
-    user_id
-}
 
 fn multipart_body(boundary: &str, filename: &str, content_type: &str, content: &str) -> String {
     format!(

--- a/backend/tests/org_management_tests.rs
+++ b/backend/tests/org_management_tests.rs
@@ -1,82 +1,13 @@
 // backend/tests/org_management_tests.rs
 
-use actix_web::{test, web, App, http::header};
+use actix_web::{test, http::header};
 use backend::handlers;
-use backend::middleware::jwt::create_jwt;
-use sqlx::{PgPool, postgres::PgPoolOptions};
-use argon2::{Argon2, PasswordHasher};
-use argon2::password_hash::SaltString;
 use uuid::Uuid;
 use serde_json::json;
 
-// Placeholder for a function that would set up the application with a test DB pool
-// and other necessary services, similar to main.rs.
-// This would ideally also handle migrations.
-async fn setup_test_app() -> (impl actix_web::dev::Service<actix_http::Request, Response = actix_web::dev::ServiceResponse, Error = actix_web::Error>, PgPool) {
-    dotenvy::dotenv().ok();
+mod test_utils;
+use test_utils::{setup_test_app, create_org, create_user, generate_jwt_token};
 
-    let database_url = std::env::var("DATABASE_URL_TEST")
-        .unwrap_or_else(|_| std::env::var("DATABASE_URL").expect("DATABASE_URL must be set"));
-
-    let pool = PgPoolOptions::new()
-        .max_connections(5)
-        .connect(&database_url)
-        .await
-        .expect("Failed to connect to test database");
-
-    sqlx::migrate!("./migrations")
-        .run(&pool)
-        .await
-        .expect("Failed to run migrations on test DB");
-
-    let app = test::init_service(
-        App::new()
-            .app_data(web::Data::new(pool.clone()))
-            // .app_data(web::Data::new(s3_client.clone())) // Add other app_data if needed by these handlers
-            .configure(handlers::init) // This should bring in your org routes
-    ).await;
-    (app, pool)
-}
-
-fn generate_jwt_token(user_id: Uuid, org_id: Uuid, role: &str) -> String {
-    std::env::set_var("JWT_SECRET", "testsecret");
-    create_jwt(user_id, org_id, role)
-}
-
-async fn create_org(pool: &PgPool, name: &str) -> Uuid {
-    let org_id = Uuid::new_v4();
-    sqlx::query("INSERT INTO organizations (id, name, api_key) VALUES ($1, $2, uuid_generate_v4())")
-        .bind(org_id)
-        .bind(name)
-        .execute(pool)
-        .await
-        .unwrap();
-    sqlx::query("INSERT INTO org_settings (org_id) VALUES ($1)")
-        .bind(org_id)
-        .execute(pool)
-        .await
-        .unwrap();
-    org_id
-}
-
-async fn create_user(pool: &PgPool, org_id: Uuid, email: &str, role: &str) -> Uuid {
-    let user_id = Uuid::new_v4();
-    let salt = SaltString::generate(&mut rand::thread_rng());
-    let password_hash = Argon2::default()
-        .hash_password(b"password", &salt)
-        .unwrap()
-        .to_string();
-    sqlx::query("INSERT INTO users (id, org_id, email, password_hash, role, confirmed) VALUES ($1,$2,$3,$4,$5,true)")
-        .bind(user_id)
-        .bind(org_id)
-        .bind(email)
-        .bind(password_hash)
-        .bind(role)
-        .execute(pool)
-        .await
-        .unwrap();
-    user_id
-}
 
 
 #[actix_rt::test]

--- a/backend/tests/pipeline_tests.rs
+++ b/backend/tests/pipeline_tests.rs
@@ -1,73 +1,11 @@
 // backend/tests/pipeline_tests.rs
-use actix_web::{test, web, App, http::header};
+use actix_web::{test, http::header};
 use backend::handlers;
-use backend::middleware::jwt::create_jwt;
-use sqlx::{PgPool, postgres::PgPoolOptions};
-use argon2::{Argon2, PasswordHasher};
-use argon2::password_hash::SaltString;
 use uuid::Uuid;
 use serde_json::json;
 
-async fn setup_test_app() -> (impl actix_web::dev::Service<actix_http::Request, Response = actix_web::dev::ServiceResponse, Error = actix_web::Error>, PgPool) {
-    dotenvy::dotenv().ok();
-    let database_url = std::env::var("DATABASE_URL_TEST")
-        .unwrap_or_else(|_| std::env::var("DATABASE_URL").expect("DATABASE_URL must be set"));
-    let pool = PgPoolOptions::new()
-        .max_connections(5)
-        .connect(&database_url)
-        .await
-        .expect("Failed to connect to test database");
-    sqlx::migrate!("./migrations")
-        .run(&pool)
-        .await
-        .expect("Failed to run migrations on test DB");
-    let app = test::init_service(
-        App::new()
-            .app_data(web::Data::new(pool.clone()))
-            .configure(handlers::init)
-    ).await;
-    (app, pool)
-}
-
-fn generate_jwt_token(user_id: Uuid, org_id: Uuid, role: &str) -> String {
-    std::env::set_var("JWT_SECRET", "testsecret");
-    create_jwt(user_id, org_id, role)
-}
-
-async fn create_org(pool: &PgPool, name: &str) -> Uuid {
-    let org_id = Uuid::new_v4();
-    sqlx::query("INSERT INTO organizations (id, name, api_key) VALUES ($1, $2, uuid_generate_v4())")
-        .bind(org_id)
-        .bind(name)
-        .execute(pool)
-        .await
-        .unwrap();
-    sqlx::query("INSERT INTO org_settings (org_id) VALUES ($1)")
-        .bind(org_id)
-        .execute(pool)
-        .await
-        .unwrap();
-    org_id
-}
-
-async fn create_user(pool: &PgPool, org_id: Uuid, email: &str, role: &str) -> Uuid {
-    let user_id = Uuid::new_v4();
-    let salt = SaltString::generate(&mut rand::thread_rng());
-    let password_hash = Argon2::default()
-        .hash_password(b"password", &salt)
-        .unwrap()
-        .to_string();
-    sqlx::query("INSERT INTO users (id, org_id, email, password_hash, role, confirmed) VALUES ($1,$2,$3,$4,$5,true)")
-        .bind(user_id)
-        .bind(org_id)
-        .bind(email)
-        .bind(password_hash)
-        .bind(role)
-        .execute(pool)
-        .await
-        .unwrap();
-    user_id
-}
+mod test_utils;
+use test_utils::{setup_test_app, create_org, create_user, generate_jwt_token};
 
 #[actix_rt::test]
 async fn test_create_pipeline_success() {

--- a/backend/tests/settings_tests.rs
+++ b/backend/tests/settings_tests.rs
@@ -1,72 +1,10 @@
-use actix_web::{test, web, App, http::header};
+use actix_web::{test, http::header};
 use backend::handlers;
-use backend::middleware::jwt::create_jwt;
-use sqlx::{PgPool, postgres::PgPoolOptions};
-use argon2::{Argon2, PasswordHasher};
-use argon2::password_hash::SaltString;
 use uuid::Uuid;
 use serde_json::json;
 
-async fn setup_test_app() -> (impl actix_web::dev::Service<actix_http::Request, Response=actix_web::dev::ServiceResponse, Error=actix_web::Error>, PgPool) {
-    dotenvy::dotenv().ok();
-    let database_url = std::env::var("DATABASE_URL_TEST")
-        .unwrap_or_else(|_| std::env::var("DATABASE_URL").expect("DATABASE_URL must be set"));
-    let pool = PgPoolOptions::new()
-        .max_connections(5)
-        .connect(&database_url)
-        .await
-        .expect("Failed to connect to test database");
-    sqlx::migrate!("./migrations")
-        .run(&pool)
-        .await
-        .expect("Failed to run migrations on test DB");
-    let app = test::init_service(
-        App::new()
-            .app_data(web::Data::new(pool.clone()))
-            .configure(handlers::init)
-    ).await;
-    (app, pool)
-}
-
-fn generate_jwt_token(user_id: Uuid, org_id: Uuid, role: &str) -> String {
-    std::env::set_var("JWT_SECRET", "testsecret");
-    create_jwt(user_id, org_id, role)
-}
-
-async fn create_org(pool: &PgPool, name: &str) -> Uuid {
-    let org_id = Uuid::new_v4();
-    sqlx::query("INSERT INTO organizations (id, name, api_key) VALUES ($1, $2, uuid_generate_v4())")
-        .bind(org_id)
-        .bind(name)
-        .execute(pool)
-        .await
-        .unwrap();
-    sqlx::query("INSERT INTO org_settings (org_id) VALUES ($1)")
-        .bind(org_id)
-        .execute(pool)
-        .await
-        .unwrap();
-    org_id
-}
-
-async fn create_user(pool: &PgPool, org_id: Uuid, email: &str, role: &str) -> Uuid {
-    let user_id = Uuid::new_v4();
-    let salt = SaltString::generate(&mut rand::thread_rng());
-    let password_hash = Argon2::default()
-        .hash_password(b"password", &salt)
-        .unwrap()
-        .to_string();
-    sqlx::query("INSERT INTO users (id, org_id, email, password_hash, role, confirmed) VALUES ($1,$2,$3,$4,$5,true)")
-        .bind(user_id)
-        .bind(org_id)
-        .bind(email)
-        .bind(password_hash)
-        .bind(role)
-        .execute(pool)
-        .await
-        .unwrap();
-    user_id
-}
+mod test_utils;
+use test_utils::{setup_test_app, create_org, create_user, generate_jwt_token};
 
 #[actix_rt::test]
 async fn test_get_settings_success() {

--- a/backend/tests/test_utils.rs
+++ b/backend/tests/test_utils.rs
@@ -1,0 +1,68 @@
+use actix_web::{test, web, App};
+use backend::handlers;
+use backend::middleware::jwt::create_jwt;
+use sqlx::{PgPool, postgres::PgPoolOptions};
+use argon2::{Argon2, PasswordHasher};
+use argon2::password_hash::SaltString;
+use uuid::Uuid;
+
+pub async fn setup_test_app() -> (impl actix_web::dev::Service<actix_http::Request, Response = actix_web::dev::ServiceResponse, Error = actix_web::Error>, PgPool) {
+    dotenvy::dotenv().ok();
+    let database_url = std::env::var("DATABASE_URL_TEST")
+        .unwrap_or_else(|_| std::env::var("DATABASE_URL").expect("DATABASE_URL must be set"));
+    let pool = PgPoolOptions::new()
+        .max_connections(5)
+        .connect(&database_url)
+        .await
+        .expect("Failed to connect to test database");
+    sqlx::migrate!("./migrations")
+        .run(&pool)
+        .await
+        .expect("Failed to run migrations on test DB");
+    let app = test::init_service(
+        App::new()
+            .app_data(web::Data::new(pool.clone()))
+            .configure(handlers::init)
+    ).await;
+    (app, pool)
+}
+
+pub fn generate_jwt_token(user_id: Uuid, org_id: Uuid, role: &str) -> String {
+    std::env::set_var("JWT_SECRET", "testsecret");
+    create_jwt(user_id, org_id, role)
+}
+
+pub async fn create_org(pool: &PgPool, name: &str) -> Uuid {
+    let org_id = Uuid::new_v4();
+    sqlx::query("INSERT INTO organizations (id, name, api_key) VALUES ($1, $2, uuid_generate_v4())")
+        .bind(org_id)
+        .bind(name)
+        .execute(pool)
+        .await
+        .unwrap();
+    sqlx::query("INSERT INTO org_settings (org_id) VALUES ($1)")
+        .bind(org_id)
+        .execute(pool)
+        .await
+        .unwrap();
+    org_id
+}
+
+pub async fn create_user(pool: &PgPool, org_id: Uuid, email: &str, role: &str) -> Uuid {
+    let user_id = Uuid::new_v4();
+    let salt = SaltString::generate(&mut rand::thread_rng());
+    let password_hash = Argon2::default()
+        .hash_password(b"password", &salt)
+        .unwrap()
+        .to_string();
+    sqlx::query("INSERT INTO users (id, org_id, email, password_hash, role, confirmed) VALUES ($1,$2,$3,$4,$5,true)")
+        .bind(user_id)
+        .bind(org_id)
+        .bind(email)
+        .bind(password_hash)
+        .bind(role)
+        .execute(pool)
+        .await
+        .unwrap();
+    user_id
+}


### PR DESCRIPTION
## Summary
- add `test_utils.rs` with helper functions for integration tests
- refactor admin, settings, pipeline, org management, and document tests to use helpers

## Testing
- `cargo test --quiet` *(fails: DATABASE_URL must be set)*

------
https://chatgpt.com/codex/tasks/task_e_6861be475e248333ac253969c33ce462