### PR TITLE
Add test env example and load in tests

### DIFF
--- a/backend/.env.test
+++ b/backend/.env.test
@@ -1,0 +1,1 @@
+DATABASE_URL_TEST=postgres://postgres:postgres@localhost/testdb

--- a/backend/tests/test_utils.rs
+++ b/backend/tests/test_utils.rs
@@ -7,7 +7,7 @@ use argon2::password_hash::SaltString;
 use uuid::Uuid;
 
 pub async fn setup_test_app() -> (impl actix_web::dev::Service<actix_http::Request, Response = actix_web::dev::ServiceResponse, Error = actix_web::Error>, PgPool) {
-    dotenvy::dotenv().ok();
+    dotenvy::from_filename(".env.test").ok();
     let database_url = std::env::var("DATABASE_URL_TEST")
         .unwrap_or_else(|_| std::env::var("DATABASE_URL").expect("DATABASE_URL must be set"));
     let pool = PgPoolOptions::new()

--- a/docs/Setup.md
+++ b/docs/Setup.md
@@ -21,6 +21,12 @@
    ```
 6. The backend will be on `http://localhost:8080`, frontend on `http://localhost:5173`.
 
+7. Backend tests read `backend/.env.test` for `DATABASE_URL_TEST`. Edit the file
+   if your test database differs and run:
+   ```bash
+   cargo test --manifest-path backend/Cargo.toml
+   ```
+
 Environment variables can be tweaked in `backend/.env` to point to a different database or S3 endpoint. Ensure the bucket defined in `S3_BUCKET` exists in your MinIO or AWS account.
 `PROCESS_ONE_JOB` makes the worker exit after a single job. Setting `LOCAL_S3_DIR` lets the worker store uploaded files under that path instead of S3, handy for local tests.
 


### PR DESCRIPTION
## Summary
- add `backend/.env.test` example with `DATABASE_URL_TEST`
- load `.env.test` in `tests/test_utils.rs`
- document running tests using this env file

## Testing
- `cargo test --manifest-path backend/Cargo.toml --no-run`

------
https://chatgpt.com/codex/tasks/task_e_68620d55a41c8333ad6627bd9625b29c