### PR TITLE
Clean up cargo check warnings

### DIFF
--- a/backend/src/processing.rs
+++ b/backend/src/processing.rs
@@ -11,7 +11,6 @@ use reqwest::multipart; // Added for multipart form data
 use printpdf::*;
 use tokio::process::Command;
 use serde::Deserialize; // For CustomHeader
-use serde_json::Value; // For Value type hint
 
 // For new report generation
 use pulldown_cmark::{Parser, Event, Tag, Options as MarkdownOptions, HeadingLevel};
@@ -254,14 +253,6 @@ pub async fn run_parse_stage(
 }
 
 // Helper struct for report stage config deserialization
-#[derive(Deserialize, Debug)]
-#[serde(rename_all = "camelCase")]
-struct ReportStageConfig {
-    template: String,
-    #[serde(default)]
-    summary_fields: Vec<String>,
-}
-
 // Helper for basic placeholder replacement
 fn replace_placeholders(template: &str, data: &JsonValue) -> String {
     let mut result = template.to_string();
@@ -313,7 +304,7 @@ pub async fn generate_report_from_template(
 
     let font = doc.add_builtin_font(BuiltinFont::Helvetica)
         .map_err(|e| anyhow!("Failed to add font: {}", e.to_string()))?;
-    let mut current_layer = doc.get_page(page1).get_layer(layer1);
+    let current_layer = doc.get_page(page1).get_layer(layer1);
 
     let mut options = MarkdownOptions::empty();
     options.insert(MarkdownOptions::ENABLE_TABLES);
@@ -543,7 +534,7 @@ pub async fn run_ai(
 ///
 /// Fails if the PDF cannot be written to disk.
 pub fn generate_report(json: &serde_json::Value, path: &Path) -> Result<()> {
-    let (mut doc, page1, layer1) = PdfDocument::new("Report", Mm(210.0), Mm(297.0), "Layer1");
+    let (doc, page1, layer1) = PdfDocument::new("Report", Mm(210.0), Mm(297.0), "Layer1");
     let current_layer = doc.get_page(page1).get_layer(layer1);
     let text = json.to_string();
     let font = doc.add_builtin_font(BuiltinFont::Helvetica)?;

--- a/backend/src/worker/ai.rs
+++ b/backend/src/worker/ai.rs
@@ -5,7 +5,7 @@ use anyhow::Result;
 use aws_sdk_s3::Client as S3Client;
 use sqlx::PgPool;
 use std::env;
-use tracing::{error, info, warn};
+use tracing::{error, warn};
 
 /// Execute an AI stage and return the resulting JSON.
 pub async fn handle_ai_stage(
@@ -40,7 +40,7 @@ pub async fn handle_ai_stage(
         return Err(anyhow::anyhow!("AI endpoint missing"));
     }
 
-    let mut input_json = current_json.clone();
+    let input_json = current_json.clone();
     // prompt handling skipped
 
     // Save AI input

--- a/backend/src/worker/report.rs
+++ b/backend/src/worker/report.rs
@@ -6,14 +6,14 @@ use aws_sdk_s3::Client as S3Client;
 use serde_json::Value;
 use sqlx::PgPool;
 use std::path::Path;
-use tracing::{error, info, warn};
+use tracing::{error, info};
 
 #[derive(serde::Deserialize, Debug)]
 #[serde(rename_all = "camelCase")]
 struct ReportStageConfig {
     template: String,
-    #[serde(default)]
-    summary_fields: Vec<String>,
+    #[serde(default, rename = "summaryFields")]
+    _summary_fields: Vec<String>,
 }
 
 pub async fn handle_report_stage(

--- a/backend/tests/admin_role_tests.rs
+++ b/backend/tests/admin_role_tests.rs
@@ -1,5 +1,4 @@
 use actix_web::{test, http::header};
-use backend::handlers;
 use uuid::Uuid;
 use serde_json::json;
 

--- a/backend/tests/document_tests.rs
+++ b/backend/tests/document_tests.rs
@@ -1,8 +1,6 @@
 use actix_web::{test, web, App, http::header};
 use backend::handlers;
 use sqlx::{PgPool, postgres::PgPoolOptions};
-use uuid::Uuid;
-use serde_json::json;
 
 mod test_utils;
 use test_utils::{create_org, create_user, generate_jwt_token};

--- a/backend/tests/org_management_tests.rs
+++ b/backend/tests/org_management_tests.rs
@@ -1,7 +1,6 @@
 // backend/tests/org_management_tests.rs
 
 use actix_web::{test, http::header};
-use backend::handlers;
 use uuid::Uuid;
 use serde_json::json;
 

--- a/backend/tests/pdf_render.rs
+++ b/backend/tests/pdf_render.rs
@@ -1,7 +1,6 @@
 use backend::processing::generate_report_from_template;
 use serde_json::json;
 use lopdf::Document as PdfDoc;
-use std::fs;
 
 #[actix_rt::test]
 async fn list_and_table_render() {

--- a/backend/tests/pipeline_tests.rs
+++ b/backend/tests/pipeline_tests.rs
@@ -1,6 +1,5 @@
 // backend/tests/pipeline_tests.rs
 use actix_web::{test, http::header};
-use backend::handlers;
 use uuid::Uuid;
 use serde_json::json;
 

--- a/backend/tests/settings_tests.rs
+++ b/backend/tests/settings_tests.rs
@@ -1,6 +1,4 @@
 use actix_web::{test, http::header};
-use backend::handlers;
-use uuid::Uuid;
 use serde_json::json;
 
 mod test_utils;

--- a/backend/tests/test_utils.rs
+++ b/backend/tests/test_utils.rs
@@ -1,3 +1,4 @@
+#![allow(dead_code)]
 use actix_web::{test, web, App};
 use backend::handlers;
 use backend::middleware::jwt::create_jwt;

--- a/backend/tests/worker_job.rs
+++ b/backend/tests/worker_job.rs
@@ -1,7 +1,6 @@
 use std::time::Duration;
 use actix_rt::time::sleep;
-use backend::models::{Pipeline, NewPipeline, NewDocument, Document, NewAnalysisJob, AnalysisJob};
-use backend::models::job_stage_output::JobStageOutput;
+use backend::models::{Pipeline, NewDocument, Document, NewAnalysisJob, AnalysisJob};
 use sqlx::postgres::PgPoolOptions;
 use uuid::Uuid;
 use actix_rt;


### PR DESCRIPTION
## Summary
- remove unused imports in tests
- drop unused imports in processing and worker modules
- clean up unnecessary mut variables and restructure file type logic
- suppress dead code warnings in test utilities
- run `cargo check` with no warnings

## Testing
- `cargo check --all-targets`

------
https://chatgpt.com/codex/tasks/task_e_68623db71f288333b6600929e1ec5bf9