### PR TITLE
Add test env example

### DIFF
--- a/backend/.env.test.example
+++ b/backend/.env.test.example
@@ -1,0 +1,1 @@
+DATABASE_URL_TEST=postgres://postgres:postgres@localhost/testdb

--- a/backend/tests/test_utils.rs
+++ b/backend/tests/test_utils.rs
@@ -8,10 +8,10 @@ use argon2::password_hash::SaltString;
 use uuid::Uuid;
 
 pub async fn setup_test_app() -> (impl actix_web::dev::Service<actix_http::Request, Response = actix_web::dev::ServiceResponse, Error = actix_web::Error>, PgPool) {
+    dotenvy::from_filename(".env.test").ok();
     if let Err(_) = std::env::var("DATABASE_URL_TEST") {
         todo!("skip");
     }
-    dotenvy::from_filename(".env.test").ok();
     let database_url = std::env::var("DATABASE_URL_TEST").expect("DATABASE_URL_TEST must be set");
     let pool = PgPoolOptions::new()
         .max_connections(5)

--- a/docs/Setup.md
+++ b/docs/Setup.md
@@ -3,6 +3,7 @@
 1. Copy environment variables:
    ```bash
    cp backend/.env.example backend/.env
+   cp backend/.env.test.example backend/.env.test
    ```
 2. Ensure PostgreSQL and MinIO are running locally. Update `backend/.env` if your services use custom ports or credentials.
    Alternatively run `docker compose up -d db minio` to start the services via Docker.
@@ -21,8 +22,9 @@
    ```
 6. The backend will be on `http://localhost:8080`, frontend on `http://localhost:5173`.
 
-7. Backend tests read `backend/.env.test` for `DATABASE_URL_TEST`. Edit the file
-   if your test database differs and run:
+7. Backend tests read `backend/.env.test` for `DATABASE_URL_TEST`. Copy
+   `backend/.env.test.example` if it doesn't exist, edit it to match your setup,
+   and run:
    ```bash
    cargo test --manifest-path backend/Cargo.toml
    ```


### PR DESCRIPTION
## Summary
- add `.env.test.example`
- load this file in tests
- document using the file for running tests

## Testing
- `cargo test --manifest-path backend/Cargo.toml --no-run` *(fails: build requires network access)*

------
https://chatgpt.com/codex/tasks/task_e_68624379b3388333b0707fbd85d6b867