### PR TITLE
Fix database env check in tests

### DIFF
--- a/backend/tests/test_utils.rs
+++ b/backend/tests/test_utils.rs
@@ -8,10 +8,10 @@ use argon2::password_hash::SaltString;
 use uuid::Uuid;
 
 pub async fn setup_test_app() -> (impl actix_web::dev::Service<actix_http::Request, Response = actix_web::dev::ServiceResponse, Error = actix_web::Error>, PgPool) {
+    dotenvy::from_filename(".env.test").ok();
     if let Err(_) = std::env::var("DATABASE_URL_TEST") {
         todo!("skip");
     }
-    dotenvy::from_filename(".env.test").ok();
     let database_url = std::env::var("DATABASE_URL_TEST").expect("DATABASE_URL_TEST must be set");
     let pool = PgPoolOptions::new()
         .max_connections(5)


### PR DESCRIPTION
## Summary
- avoid panic when DATABASE_URL_TEST is unset

## Testing
- `cargo fmt --manifest-path backend/Cargo.toml --all -- --check` *(fails: unexpected closing delimiter)*
- `cargo clippy --manifest-path backend/Cargo.toml --all-targets -- --deny warnings` *(fails: too many warnings)*
- `cargo test --manifest-path backend/Cargo.toml` *(failed to compile in time)*

------
https://chatgpt.com/codex/tasks/task_e_68624362ea348333a4a36ae19f1fe457