### PR TITLE
Add vitest coverage for PipelineEditor

### DIFF
--- a/frontend/src/lib/components/PipelineEditor.svelte
+++ b/frontend/src/lib/components/PipelineEditor.svelte
@@ -43,7 +43,12 @@
   export let initialPipeline: Pipeline | null = null;
 
   // Internal reactive state for the pipeline being edited
-  let pipeline: Pipeline;
+  let pipeline: Pipeline = {
+    id: undefined,
+    org_id: orgId,
+    name: '',
+    stages: [],
+  };
 
   function resetPipeline() {
     pipeline = {
@@ -674,7 +679,7 @@
                 bind:value={stage.config.template}
                 rows={8}
                 class="glass-input w-full !text-sm custom-scrollbar !bg-neutral-600/50 !border-neutral-500/70 !text-gray-100"
-                placeholder="Enter Markdown template. Use {{placeholder.path}} for data. e.g., {{document_name}}, {{ai_result.summary}}"
+                placeholder={'Enter Markdown template. Use {{placeholder.path}} for data. e.g., {{document_name}}, {{ai_result.summary}}'}
               ></textarea>
               <p class="text-sm font-light text-gray-400 dark:text-gray-500 mt-1">
                 Available placeholders depend on data from previous stages (e.g., `ai_result`, `parse_result`) and job metadata (`document_name`, `job_id`).

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -1,8 +1,14 @@
 import { defineConfig } from 'vite';
 import { svelte, vitePreprocess } from '@sveltejs/vite-plugin-svelte';
+import { resolve } from 'path';
 
 export default defineConfig({
   plugins: [svelte({ preprocess: vitePreprocess() })],
+  resolve: {
+    alias: {
+      $lib: resolve('./src/lib')
+    }
+  },
   server: {
     port: 5173
   },


### PR DESCRIPTION
## Summary
- fix compile errors in PipelineEditor
- support $lib alias for vitest
- add PipelineEditor vitest and enable stage tests

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6863ca5cc7588333bcf564b4d50f38ec