### PR TITLE
Implement external OCR check

### DIFF
--- a/backend/src/worker/ocr.rs
+++ b/backend/src/worker/ocr.rs
@@ -17,7 +17,10 @@ pub async fn handle_ocr_stage(
     local: &Path,
     txt_path: &Path,
 ) -> Result<bool> {
-    let text_result = if stage.ocr_engine.as_deref() == Some("external") {
+    // Check if this stage should use an external OCR engine
+    let use_external = stage.ocr_engine.as_deref() == Some("external");
+
+    let text_result = if use_external {
         let endpoint = stage
             .ocr_stage_endpoint
             .clone()


### PR DESCRIPTION
## Summary
- add an explicit flag to check whether OCR should use an external service

## Testing
- `SKIP_DB=1 cargo test --lib --quiet`

------
https://chatgpt.com/codex/tasks/task_e_6863d46523648333990d39e0daffbfd8