### PR TITLE
Refactor admin handlers into submodules

### DIFF
--- a/backend/src/handlers/admin/invites.rs
+++ b/backend/src/handlers/admin/invites.rs
@@ -1,0 +1,97 @@
+use actix_web::{post, web, HttpResponse};
+use serde::Deserialize;
+use sqlx::PgPool;
+use uuid::Uuid;
+use crate::middleware::auth::AuthUser;
+use crate::models::{User as UserModel, NewUser};
+use crate::email::send_email;
+use argon2::{Argon2, PasswordHasher};
+use argon2::password_hash::SaltString;
+use rand::Rng;
+
+#[derive(Deserialize, Debug)]
+pub struct InviteUserPayload {
+    pub email: String,
+    pub org_id: Uuid,
+    pub role: Option<String>,
+}
+
+#[post("/admin/invite")]
+pub async fn invite_user(
+    admin: AuthUser,
+    payload: web::Json<InviteUserPayload>,
+    pool: web::Data<PgPool>,
+) -> HttpResponse {
+    if admin.role != "admin" {
+        return HttpResponse::Forbidden()
+            .json(serde_json::json!({"error": "Only global administrators can invite users."}));
+    }
+    let email = payload.email.trim().to_lowercase();
+    if email.is_empty() || !email.contains('@') {
+        return HttpResponse::BadRequest().json(serde_json::json!({"error": "Invalid email address."}));
+    }
+
+    match UserModel::find_by_email(&pool, &email).await {
+        Ok(_) => {
+            return HttpResponse::Conflict()
+                .json(serde_json::json!({"error": "A user with this email already exists."}));
+        }
+        Err(sqlx::Error::RowNotFound) => {}
+        Err(e) => {
+            log::error!("DB error checking for existing user {}: {:?}", email, e);
+            return HttpResponse::InternalServerError()
+                .json(serde_json::json!({"error": "Database error checking email."}));
+        }
+    }
+
+    let placeholder_password: String = rand::thread_rng()
+        .sample_iter(&rand::distributions::Alphanumeric)
+        .take(16)
+        .map(char::from)
+        .collect();
+    let salt = SaltString::generate(&mut rand::thread_rng());
+    let password_hash = match Argon2::default().hash_password(placeholder_password.as_bytes(), &salt) {
+        Ok(hash) => hash.to_string(),
+        Err(e) => {
+            log::error!("Failed to hash placeholder password for invite: {:?}", e);
+            return HttpResponse::InternalServerError()
+                .json(serde_json::json!({"error": "Failed to process invitation."}));
+        }
+    };
+
+    let role = payload.role.clone().unwrap_or_else(|| "user".into());
+    let new_user_data = NewUser {
+        org_id: payload.org_id,
+        email: email.clone(),
+        password_hash,
+        role,
+    };
+
+    match UserModel::create(&pool, new_user_data).await {
+        Ok(created_user) => {
+            let base_url = std::env::var("BASE_URL").unwrap_or_else(|_| "http://localhost:8080".into());
+            let confirmation_link = format!("{}/api/confirm/{}", base_url, created_user.confirmation_token.unwrap_or_default());
+
+            let email_subject = "You're invited to crPipeline";
+            let email_body = format!(
+                "Hello,\n\nYou have been invited to join crPipeline. Click the link below to confirm your account:\n{}\n",
+                confirmation_link
+            );
+            if let Err(e) = send_email(&email, email_subject, &email_body).await {
+                log::error!("Failed to send invite email to {}: {:?}", email, e);
+                HttpResponse::Accepted().json(serde_json::json!({
+                    "success": true,
+                    "message": "User created but email could not be sent.",
+                    "user_id": created_user.id
+                }))
+            } else {
+                HttpResponse::Ok().json(serde_json::json!({"success": true, "user_id": created_user.id}))
+            }
+        }
+        Err(e) => {
+            log::error!("Failed to create invited user {}: {:?}", email, e);
+            HttpResponse::InternalServerError().json(serde_json::json!({"error": "Failed to create user."}))
+        }
+    }
+}
+

--- a/backend/src/handlers/admin/mod.rs
+++ b/backend/src/handlers/admin/mod.rs
@@ -1,0 +1,25 @@
+use actix_web::web;
+
+pub mod user_management;
+pub mod invites;
+
+pub use user_management::{
+    list_all_users,
+    assign_user_role,
+    update_user_profile,
+    resend_confirmation_email,
+    deactivate_user,
+    reactivate_user,
+};
+
+pub use invites::invite_user;
+
+pub fn routes(cfg: &mut web::ServiceConfig) {
+    cfg.service(list_all_users)
+        .service(assign_user_role)
+        .service(resend_confirmation_email)
+        .service(deactivate_user)
+        .service(reactivate_user)
+        .service(invite_user)
+        .service(update_user_profile);
+}

--- a/backend/src/handlers/admin/user_management.rs
+++ b/backend/src/handlers/admin/user_management.rs
@@ -1,43 +1,38 @@
-use actix_web::{get, post, web, HttpResponse, Responder};
+use actix_web::{get, post, put, web, HttpResponse, Responder};
 use serde::{Serialize, Deserialize};
 use sqlx::{FromRow, PgPool};
 use uuid::Uuid;
-use crate::middleware::auth::AuthUser;
-use crate::models::{User as UserModel, NewUser}; // Added NewUser
 use chrono::{DateTime, Utc};
+use crate::middleware::auth::AuthUser;
+use crate::models::User as UserModel;
 use crate::email::send_email;
-use argon2::{Argon2, PasswordHasher}; // For placeholder password in invite
-use argon2::password_hash::SaltString; // For placeholder password in invite
-use rand::Rng;
 
-
-#[derive(Deserialize, Debug)] // For request payload
-struct AssignRolePayload {
-    role: String,
-    org_id: Option<Uuid>,
+#[derive(Deserialize, Debug)]
+pub struct AssignRolePayload {
+    pub role: String,
+    pub org_id: Option<Uuid>,
 }
 
-#[derive(Serialize, FromRow, Debug)] // For list_all_users response
-struct AdminUserView {
-    id: Uuid,
-    email: String,
-    role: String,
-    org_id: Uuid,
-    organization_name: Option<String>,
-    confirmed: bool,
-    is_active: bool,
-    deactivated_at: Option<DateTime<Utc>>,
+#[derive(Serialize, FromRow, Debug)]
+pub struct AdminUserView {
+    pub id: Uuid,
+    pub email: String,
+    pub role: String,
+    pub org_id: Uuid,
+    pub organization_name: Option<String>,
+    pub confirmed: bool,
+    pub is_active: bool,
+    pub deactivated_at: Option<DateTime<Utc>>,
 }
 
 #[get("/admin/users")]
-async fn list_all_users(user: AuthUser, pool: web::Data<PgPool>) -> impl Responder {
-    // 1. Authorization: Only global admins
+pub async fn list_all_users(user: AuthUser, pool: web::Data<PgPool>) -> impl Responder {
     if user.role != "admin" {
-        return HttpResponse::Forbidden().json(serde_json::json!({"error": "You do not have permission to access this resource."}));
+        return HttpResponse::Forbidden()
+            .json(serde_json::json!({"error": "You do not have permission to access this resource."}));
     }
 
-    // 2. Fetch all users with their organization names
-    let query = "
+    let query = r#"
         SELECT
             u.id,
             u.email,
@@ -53,7 +48,7 @@ async fn list_all_users(user: AuthUser, pool: web::Data<PgPool>) -> impl Respond
             organizations o ON u.org_id = o.id
         ORDER BY
             u.email ASC
-    ";
+    "#;
 
     match sqlx::query_as::<_, AdminUserView>(query)
         .fetch_all(pool.as_ref())
@@ -68,32 +63,30 @@ async fn list_all_users(user: AuthUser, pool: web::Data<PgPool>) -> impl Respond
 }
 
 #[post("/admin/users/{user_id}/assign_role")]
-async fn assign_user_role(
-    path_params: web::Path<Uuid>,    // user_id of the target user
+pub async fn assign_user_role(
+    path_params: web::Path<Uuid>,
     payload: web::Json<AssignRolePayload>,
-    current_admin_user: AuthUser, // The authenticated global admin performing the action
+    current_admin_user: AuthUser,
     pool: web::Data<PgPool>,
 ) -> HttpResponse {
     let target_user_id = path_params.into_inner();
 
-    // 1. Authorization: Only global admins can perform this
     if current_admin_user.role != "admin" {
-        return HttpResponse::Forbidden().json(serde_json::json!({"error": "Only global administrators can assign roles."}));
+        return HttpResponse::Forbidden()
+            .json(serde_json::json!({"error": "Only global administrators can assign roles."}));
     }
 
-    // 2. Validation:
-    // 2a. Admin cannot change their own role via this endpoint
     if target_user_id == current_admin_user.user_id {
-        return HttpResponse::BadRequest().json(serde_json::json!({"error": "Administrators cannot change their own role using this endpoint."}));
+        return HttpResponse::BadRequest()
+            .json(serde_json::json!({"error": "Administrators cannot change their own role using this endpoint."}));
     }
 
-    // 2b. Validate the target role string
     let new_role = payload.role.trim().to_lowercase();
     if new_role != "user" && new_role != "org_admin" {
-        return HttpResponse::BadRequest().json(serde_json::json!({"error": "Invalid role specified. Allowed roles are 'user' or 'org_admin'."}));
+        return HttpResponse::BadRequest()
+            .json(serde_json::json!({"error": "Invalid role specified. Allowed roles are 'user' or 'org_admin'."}));
     }
 
-    // 2c. If assigning "org_admin", org_id must be provided and valid
     let mut target_org_id_for_update: Option<Uuid> = None;
     if new_role == "org_admin" {
         match payload.org_id {
@@ -104,21 +97,26 @@ async fn assign_user_role(
                     .await
                 {
                     Ok(exists) if exists => target_org_id_for_update = Some(org_uuid),
-                    Ok(_) => return HttpResponse::BadRequest().json(serde_json::json!({"error": format!("Organization with ID {} not found.", org_uuid)})),
+                    Ok(_) => {
+                        return HttpResponse::BadRequest()
+                            .json(serde_json::json!({"error": format!("Organization with ID {} not found.", org_uuid)}));
+                    }
                     Err(e) => {
                         log::error!("Failed to check existence of org_id {}: {:?}", org_uuid, e);
-                        return HttpResponse::InternalServerError().json(serde_json::json!({"error": "Database error validating organization."}));
+                        return HttpResponse::InternalServerError()
+                            .json(serde_json::json!({"error": "Database error validating organization."}));
                     }
                 }
             }
-            None => return HttpResponse::BadRequest().json(serde_json::json!({"error": "An organization ID is required when assigning the 'org_admin' role."})),
+            None =>
+                return HttpResponse::BadRequest()
+                    .json(serde_json::json!({"error": "An organization ID is required when assigning the 'org_admin' role."})),
         }
     }
 
-    // 3. Fetch the target user
-    let target_user = match sqlx::query_as::<_, UserModel>("SELECT * FROM users WHERE id = $1") // Use aliased UserModel
+    let target_user = match sqlx::query_as::<_, UserModel>("SELECT * FROM users WHERE id = $1")
         .bind(target_user_id)
-        .fetch_optional(pool.as_ref()) // Use fetch_optional for better error handling if user not found
+        .fetch_optional(pool.as_ref())
         .await
     {
         Ok(Some(user)) => user,
@@ -129,42 +127,44 @@ async fn assign_user_role(
         }
     };
 
-    // 4. Safety Check: Prevent removing the last global admin's "admin" role
     if target_user.role == "admin" && new_role != "admin" {
         match sqlx::query_scalar::<_, i64>("SELECT COUNT(*) FROM users WHERE role = 'admin'")
             .fetch_one(pool.as_ref())
             .await
         {
             Ok(admin_count) if admin_count <= 1 => {
-                return HttpResponse::Forbidden().json(serde_json::json!({"error": "Cannot remove the last global administrator's 'admin' role."}));
+                return HttpResponse::Forbidden()
+                    .json(serde_json::json!({"error": "Cannot remove the last global administrator's 'admin' role."}));
             }
-            Ok(_) => {} // Proceed if other admins exist
+            Ok(_) => {}
             Err(e) => {
                 log::error!("Failed to count admin users: {:?}", e);
-                return HttpResponse::InternalServerError().json(serde_json::json!({"error": "Database error during safety check."}));
+                return HttpResponse::InternalServerError()
+                    .json(serde_json::json!({"error": "Database error during safety check."}));
             }
         }
     }
 
-    // 5. Update user's role and org_id
     let final_org_id_to_set = match payload.org_id {
         Some(new_org_uuid) => {
             if new_role != "org_admin" {
-                 match sqlx::query_scalar::<_, bool>("SELECT EXISTS(SELECT 1 FROM organizations WHERE id = $1)")
-                     .bind(new_org_uuid)
-                     .fetch_one(pool.as_ref())
-                     .await
-                 {
-                     Ok(exists) if exists => new_org_uuid,
-                     Ok(_) => {
-                         log::warn!("Invalid org_id {} provided for user role update when role is 'user'.", new_org_uuid);
-                         return HttpResponse::BadRequest().json(serde_json::json!({"error": format!("Organization with ID {} not found.", new_org_uuid)}));
-                     }
-                     Err(e) => {
-                         log::error!("Failed to check existence of org_id {} for user role update: {:?}", new_org_uuid, e);
-                         return HttpResponse::InternalServerError().json(serde_json::json!({"error": "Database error validating organization."}));
-                     }
-                 }
+                match sqlx::query_scalar::<_, bool>("SELECT EXISTS(SELECT 1 FROM organizations WHERE id = $1)")
+                    .bind(new_org_uuid)
+                    .fetch_one(pool.as_ref())
+                    .await
+                {
+                    Ok(exists) if exists => new_org_uuid,
+                    Ok(_) => {
+                        log::warn!("Invalid org_id {} provided for user role update when role is 'user'.", new_org_uuid);
+                        return HttpResponse::BadRequest()
+                            .json(serde_json::json!({"error": format!("Organization with ID {} not found.", new_org_uuid)}));
+                    }
+                    Err(e) => {
+                        log::error!("Failed to check existence of org_id {} for user role update: {:?}", new_org_uuid, e);
+                        return HttpResponse::InternalServerError()
+                            .json(serde_json::json!({"error": "Database error validating organization."}));
+                    }
+                }
             } else {
                 target_org_id_for_update.unwrap()
             }
@@ -188,8 +188,6 @@ async fn assign_user_role(
         Ok(_) => {
             log::warn!("User {} role update to {} for org_id {} attempted by admin {}, but no rows affected (user might not exist or data was the same).",
                 target_user_id, new_role, final_org_id_to_set, current_admin_user.user_id);
-            // User was fetched successfully earlier, so this likely means data was the same or concurrent modification.
-            // Or, if role and org_id were already set to these values.
             HttpResponse::Ok().json(serde_json::json!({"success": true, "message": "User role and org assignment are already up to date or user not found during update."}))
         }
         Err(e) => {
@@ -199,23 +197,13 @@ async fn assign_user_role(
     }
 }
 
-pub fn routes(cfg: &mut web::ServiceConfig) {
-    cfg.service(list_all_users)
-       .service(assign_user_role)
-       .service(resend_confirmation_email)
-       .service(deactivate_user)
-       .service(reactivate_user)
-       .service(invite_user) // Keep one invite_user service
-       .service(update_user_profile);
-}
-
 #[derive(Deserialize, Debug)]
-struct UpdateUserProfilePayload {
-    email: Option<String>,
+pub struct UpdateUserProfilePayload {
+    pub email: Option<String>,
 }
 
-#[actix_web::put("/admin/users/{user_id}/profile")]
-async fn update_user_profile(
+#[put("/admin/users/{user_id}/profile")]
+pub async fn update_user_profile(
     path_params: web::Path<Uuid>,
     payload: web::Json<UpdateUserProfilePayload>,
     current_admin_user: AuthUser,
@@ -224,7 +212,8 @@ async fn update_user_profile(
     let target_user_id = path_params.into_inner();
 
     if current_admin_user.role != "admin" {
-        return HttpResponse::Forbidden().json(serde_json::json!({"error": "Only global administrators can update user profiles."}));
+        return HttpResponse::Forbidden()
+            .json(serde_json::json!({"error": "Only global administrators can update user profiles."}));
     }
 
     let target_user = match UserModel::find_by_id_for_admin(&pool, target_user_id).await {
@@ -246,10 +235,9 @@ async fn update_user_profile(
         }
 
         if trimmed_new_email.to_lowercase() != target_user.email.to_lowercase() {
-            // Email is changing. Check for uniqueness.
             match UserModel::find_by_email(&pool, trimmed_new_email).await {
                 Ok(_existing_user) => return HttpResponse::Conflict().json(serde_json::json!({"error": "New email address is already in use."})),
-                Err(sqlx::Error::RowNotFound) => { /* New email is available */ }
+                Err(sqlx::Error::RowNotFound) => {}
                 Err(e) => {
                     log::error!("DB error checking new email existence for user {}: {:?}", target_user_id, e);
                     return HttpResponse::InternalServerError().json(serde_json::json!({"error": "Database error checking email availability."}));
@@ -265,14 +253,14 @@ async fn update_user_profile(
                     let confirmation_link = format!("{}/api/confirm/{}", base_url, new_confirmation_token);
                     let email_subject = "Your Email Address Was Changed - Confirm New Email";
                     let email_body = format!(
-r#"Hello,
+                        r#"Hello,
 
 Your email address associated with crPipeline was changed by an administrator to {}.
 Please confirm this new email address by clicking the link below:
 {}
 
 If you did not request this change, please contact support immediately."#,
-trimmed_new_email, confirmation_link);
+                        trimmed_new_email, confirmation_link);
 
                     if let Err(e) = send_email(trimmed_new_email, email_subject, &email_body).await {
                         log::error!("Failed to send confirmation email to new address {}: {:?}", trimmed_new_email, e);
@@ -297,96 +285,8 @@ trimmed_new_email, confirmation_link);
     }
 }
 
-// Removed duplicated InviteUserPayload and other functions that were part of the incorrect SEARCH block
-
-#[derive(Deserialize, Debug)]
-struct InviteUserPayload {
-    email: String,
-    org_id: Uuid,
-    role: Option<String>,
-}
-
-#[post("/admin/invite")]
-async fn invite_user(
-    admin: AuthUser,
-    payload: web::Json<InviteUserPayload>,
-    pool: web::Data<PgPool>,
-) -> HttpResponse {
-    if admin.role != "admin" {
-        return HttpResponse::Forbidden()
-            .json(serde_json::json!({"error": "Only global administrators can invite users."}));
-    }
-    let email = payload.email.trim().to_lowercase();
-    if email.is_empty() || !email.contains('@') {
-        return HttpResponse::BadRequest().json(serde_json::json!({"error": "Invalid email address."}));
-    }
-
-    match UserModel::find_by_email(&pool, &email).await {
-        Ok(_) => {
-            return HttpResponse::Conflict()
-                .json(serde_json::json!({"error": "A user with this email already exists."}));
-        }
-        Err(sqlx::Error::RowNotFound) => {}
-        Err(e) => {
-            log::error!("DB error checking for existing user {}: {:?}", email, e);
-            return HttpResponse::InternalServerError()
-                .json(serde_json::json!({"error": "Database error checking email."}));
-        }
-    }
-
-    let placeholder_password: String = rand::thread_rng()
-        .sample_iter(&rand::distributions::Alphanumeric)
-        .take(16)
-        .map(char::from)
-        .collect();
-    let salt = SaltString::generate(&mut rand::thread_rng());
-    let password_hash = match Argon2::default().hash_password(placeholder_password.as_bytes(), &salt) {
-        Ok(hash) => hash.to_string(),
-        Err(e) => {
-            log::error!("Failed to hash placeholder password for invite: {:?}", e);
-            return HttpResponse::InternalServerError()
-                .json(serde_json::json!({"error": "Failed to process invitation."}));
-        }
-    };
-
-    let role = payload.role.clone().unwrap_or_else(|| "user".into());
-    let new_user_data = NewUser {
-        org_id: payload.org_id,
-        email: email.clone(),
-        password_hash,
-        role,
-    };
-
-    match UserModel::create(&pool, new_user_data).await {
-        Ok(created_user) => {
-            let base_url = std::env::var("BASE_URL").unwrap_or_else(|_| "http://localhost:8080".into());
-            let confirmation_link = format!("{}/api/confirm/{}", base_url, created_user.confirmation_token.unwrap_or_default());
-
-            let email_subject = "You're invited to crPipeline";
-            let email_body = format!(
-                "Hello,\n\nYou have been invited to join crPipeline. Click the link below to confirm your account:\n{}\n",
-                confirmation_link
-            );
-            if let Err(e) = send_email(&email, email_subject, &email_body).await {
-                log::error!("Failed to send invite email to {}: {:?}", email, e);
-                HttpResponse::Accepted().json(serde_json::json!({
-                    "success": true,
-                    "message": "User created but email could not be sent.",
-                    "user_id": created_user.id
-                }))
-            } else {
-                HttpResponse::Ok().json(serde_json::json!({"success": true, "user_id": created_user.id}))
-            }
-        }
-        Err(e) => {
-            log::error!("Failed to create invited user {}: {:?}", email, e);
-            HttpResponse::InternalServerError().json(serde_json::json!({"error": "Failed to create user."}))
-        }
-    }
-}
-
 #[post("/admin/users/{user_id}/resend_confirmation")]
-async fn resend_confirmation_email(
+pub async fn resend_confirmation_email(
     admin: AuthUser,
     path: web::Path<Uuid>,
     pool: web::Data<PgPool>,
@@ -438,7 +338,7 @@ async fn resend_confirmation_email(
 }
 
 #[post("/admin/users/{user_id}/deactivate")]
-async fn deactivate_user(
+pub async fn deactivate_user(
     admin: AuthUser,
     path: web::Path<Uuid>,
     pool: web::Data<PgPool>,
@@ -462,7 +362,7 @@ async fn deactivate_user(
 }
 
 #[post("/admin/users/{user_id}/reactivate")]
-async fn reactivate_user(
+pub async fn reactivate_user(
     admin: AuthUser,
     path: web::Path<Uuid>,
     pool: web::Data<PgPool>,
@@ -484,3 +384,4 @@ async fn reactivate_user(
         }
     }
 }
+


### PR DESCRIPTION
## Summary
- split `admin.rs` into `user_management.rs` and `invites.rs`
- re-export new modules from `admin/mod.rs`
- keep `admin::routes()` as entrypoint

## Testing
- `cargo test --no-run --offline` *(fails: build interrupted)*

------
https://chatgpt.com/codex/tasks/task_e_6863dfd5048c8333ae39f3aedbe37700