### PR TITLE
Add rate limit integration tests

### DIFF
--- a/backend/tests/rate_limit_tests.rs
+++ b/backend/tests/rate_limit_tests.rs
@@ -15,7 +15,7 @@ async fn start_redis() -> (oneshot::Sender<()>, u16) {
     let port = listener.local_addr().unwrap().port();
     let (tx, rx) = oneshot::channel();
     tokio::spawn(async move {
-        server::run(listener, async {
+        let _ = server::run(listener, async {
             let _ = rx.await;
         })
         .await;


### PR DESCRIPTION
## Summary
- fix spawn call in rate limit tests

## Testing
- `cargo test -- --test rate_limit_tests --nocapture`

------
https://chatgpt.com/codex/tasks/task_e_6863dfd3576c83339a3eee568239bf19