### PR TITLE
Implement scheduled cleanup

### DIFF
--- a/backend/src/bin/cleanup.rs
+++ b/backend/src/bin/cleanup.rs
@@ -1,10 +1,41 @@
-use dotenvy::dotenv;
-use sqlx::postgres::PgPoolOptions;
-use std::env;
 use aws_config::meta::region::RegionProviderChain;
 use aws_sdk_s3::Client as S3Client;
 use backend::models::Document;
-use tracing::{info, error};
+use dotenvy::dotenv;
+use sqlx::postgres::PgPoolOptions;
+use std::{env, time::Duration};
+use tracing::{error, info};
+
+async fn run_cleanup(
+    pool: &sqlx::Pool<sqlx::Postgres>,
+    s3: &S3Client,
+    bucket: &str,
+) -> anyhow::Result<()> {
+    let expired: Vec<Document> = sqlx::query_as(
+        "SELECT * FROM documents WHERE expires_at IS NOT NULL AND expires_at < NOW()",
+    )
+    .fetch_all(pool)
+    .await?;
+
+    for doc in expired {
+        if let Err(e) = s3
+            .delete_object()
+            .bucket(bucket)
+            .key(&doc.filename)
+            .send()
+            .await
+        {
+            error!("failed to delete {}: {:?}", doc.filename, e);
+            continue;
+        }
+        sqlx::query("DELETE FROM documents WHERE id=$1")
+            .bind(doc.id)
+            .execute(pool)
+            .await?;
+        info!("Deleted expired document {}", doc.filename);
+    }
+    Ok(())
+}
 
 /// Remove expired documents and their blobs from storage.
 #[tokio::main]
@@ -12,29 +43,26 @@ async fn main() -> anyhow::Result<()> {
     dotenv().ok();
     tracing_subscriber::fmt::init();
     let database_url = env::var("DATABASE_URL")?;
-    let pool = PgPoolOptions::new().max_connections(5).connect(&database_url).await?;
+    let pool = PgPoolOptions::new()
+        .max_connections(5)
+        .connect(&database_url)
+        .await?;
 
     let region_provider = RegionProviderChain::default_provider().or_else("us-east-1");
     let shared = aws_config::from_env().region(region_provider).load().await;
     let s3 = S3Client::new(&shared);
     let bucket = env::var("S3_BUCKET").unwrap_or_else(|_| "uploads".into());
 
-    let expired: Vec<Document> = sqlx::query_as(
-        "SELECT * FROM documents WHERE expires_at IS NOT NULL AND expires_at < NOW()"
-    )
-    .fetch_all(&pool)
-    .await?;
-
-    for doc in expired {
-        if let Err(e) = s3.delete_object().bucket(&bucket).key(&doc.filename).send().await {
-            error!("failed to delete {}: {:?}", doc.filename, e);
-            continue;
+    if let Ok(interval) = env::var("CLEANUP_INTERVAL_MINUTES")
+        .ok()
+        .and_then(|v| v.parse::<u64>().ok())
+    {
+        loop {
+            run_cleanup(&pool, &s3, &bucket).await?;
+            tokio::time::sleep(Duration::from_secs(interval * 60)).await;
         }
-        sqlx::query("DELETE FROM documents WHERE id=$1")
-            .bind(doc.id)
-            .execute(&pool)
-            .await?;
-        info!("Deleted expired document {}", doc.filename);
+    } else {
+        run_cleanup(&pool, &s3, &bucket).await?;
     }
 
     Ok(())

--- a/docs/Usage.md
+++ b/docs/Usage.md
@@ -49,9 +49,29 @@ REDIS_URL=redis://redis:6379/ ./target/release/worker
 Running the command in several processes allows jobs to be handled concurrently.
 
 ## Cleanup
-Remove expired documents periodically:
+Remove expired documents that have passed their `expires_at` timestamp.
+
+Run once:
 ```bash
 cargo run --bin cleanup
+```
+
+Set `CLEANUP_INTERVAL_MINUTES` to continuously run on a schedule:
+```bash
+CLEANUP_INTERVAL_MINUTES=60 cargo run --bin cleanup
+```
+
+### Cron
+After compiling the cleanup binary in release mode, invoke it from cron using `scripts/cleanup_cron.sh`:
+```
+0 * * * * /path/to/project/scripts/cleanup_cron.sh
+```
+
+### Kubernetes CronJob
+An example CronJob manifest is provided at `k8s/cleanup-cronjob.yaml`.
+Apply it with:
+```bash
+kubectl apply -f k8s/cleanup-cronjob.yaml
 ```
 
 ## Production Build

--- a/k8s/cleanup-cronjob.yaml
+++ b/k8s/cleanup-cronjob.yaml
@@ -1,0 +1,18 @@
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: cleanup-job
+spec:
+  schedule: "0 * * * *"
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          containers:
+          - name: cleanup
+            image: myorg/backend:latest
+            command: ["/usr/local/bin/cleanup"]
+            envFrom:
+            - secretRef:
+                name: backend-env
+          restartPolicy: OnFailure

--- a/scripts/cleanup_cron.sh
+++ b/scripts/cleanup_cron.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+# Run the cleanup binary built in release mode. Intended for cron.
+set -e
+cd "$(dirname "$0")/.."
+exec ./target/release/cleanup


### PR DESCRIPTION
## Summary
- add environment-based interval loop to cleanup binary
- provide cron script and Kubernetes CronJob sample
- document periodic cleanup usage

## Testing
- `rustfmt --edition 2021 backend/src/bin/cleanup.rs`
- `cargo clippy --manifest-path backend/Cargo.toml --all-targets -- --deny warnings` *(fails: collapsible if, etc.)*
- `cargo test --manifest-path backend/Cargo.toml --all-targets -- --test-threads=1` *(interrupted due to long build)*
- `./scripts/check_cli_errors.sh` *(interrupted due to long build)*

------
https://chatgpt.com/codex/tasks/task_e_6864388669908333a301655d40e28217