### PR TITLE
Implement basic login and registration pages

### DIFF
--- a/frontend/src/lib/components/LoginForm.svelte
+++ b/frontend/src/lib/components/LoginForm.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import { createEventDispatcher } from 'svelte';
+  import { apiFetch } from '$lib/utils/apiUtils';
 
   const dispatch = createEventDispatcher();
   let email = '';
@@ -8,9 +9,8 @@
 
   async function submit() {
     error = '';
-    const res = await fetch('/api/login', {
+    const res = await apiFetch('/api/login', {
       method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ email, password })
     });
     if (res.ok) {

--- a/frontend/src/lib/components/__tests__/LoginForm.test.ts
+++ b/frontend/src/lib/components/__tests__/LoginForm.test.ts
@@ -11,5 +11,6 @@ test('emits loggedin on successful submit', async () => {
   component.$on('loggedin', handler);
   await fireEvent.click(getByText('Login'));
   await tick();
+  await tick();
   expect(handler).toHaveBeenCalled();
 });

--- a/frontend/src/routes/+page.svelte
+++ b/frontend/src/routes/+page.svelte
@@ -47,7 +47,7 @@
         Advanced document processing and analysis.
       </p>
       <p class="text-md text-gray-700 dark:text-gray-200">
-        Please <a href="/api/login_page_placeholder" class="text-accent hover:underline font-medium">login</a> to access your dashboard and features.
+        Please <a href="/login" class="text-accent hover:underline font-medium">login</a> to access your dashboard and features.
       </p>
       <p class="text-xs text-gray-500 dark:text-gray-400 mt-4">
         (This is the root page. If you have an account, logging in will redirect you to your dashboard.

--- a/frontend/src/routes/dashboard/+page.svelte
+++ b/frontend/src/routes/dashboard/+page.svelte
@@ -72,7 +72,7 @@
     <!-- This state should ideally be handled by redirects in +layout.ts or +page.ts -->
     <GlassCard title="Access Denied" padding="p-6" customClass="text-center">
       <p class="text-gray-400">You need to be logged in to view the dashboard.</p>
-      <a href="/login_placeholder" class="mt-4 inline-block text-accent hover:underline">Go to Login (Placeholder)</a>
+      <a href="/login" class="mt-4 inline-block text-accent hover:underline">Go to Login</a>
     </GlassCard>
   {/if}
 </div>

--- a/frontend/src/routes/login/+page.svelte
+++ b/frontend/src/routes/login/+page.svelte
@@ -1,0 +1,43 @@
+<script lang="ts">
+  import { goto } from '$app/navigation';
+  import GlassCard from '$lib/components/GlassCard.svelte';
+  import Button from '$lib/components/Button.svelte';
+  import { apiFetch } from '$lib/utils/apiUtils';
+
+  let email = '';
+  let password = '';
+  let error: string | null = null;
+
+  async function submit() {
+    error = null;
+    try {
+      const res = await apiFetch('/api/login', {
+        method: 'POST',
+        body: JSON.stringify({ email, password })
+      });
+      if (res.ok) {
+        goto('/dashboard');
+      } else {
+        const data = await res.json().catch(() => ({ error: 'Login failed' }));
+        error = data.error || 'Login failed';
+      }
+    } catch (e: any) {
+      error = e.message || 'Login failed';
+    }
+  }
+</script>
+
+<div class="min-h-screen flex items-center justify-center p-4">
+  <GlassCard padding="p-6" customClass="w-full max-w-md text-center space-y-4">
+    <h1 class="text-2xl font-semibold mb-2">Login</h1>
+    <form class="space-y-4" on:submit|preventDefault={submit}>
+      <input class="glass-input w-full" type="email" bind:value={email} placeholder="Email" required />
+      <input class="glass-input w-full" type="password" bind:value={password} placeholder="Password" required />
+      {#if error}
+        <p class="text-red-500 text-sm">{error}</p>
+      {/if}
+      <Button type="submit" variant="primary" customClass="w-full">Login</Button>
+    </form>
+    <p class="text-sm">Don't have an account? <a href="/register" class="text-accent hover:underline">Register</a></p>
+  </GlassCard>
+</div>

--- a/frontend/src/routes/register/+page.svelte
+++ b/frontend/src/routes/register/+page.svelte
@@ -1,0 +1,50 @@
+<script lang="ts">
+  import { goto } from '$app/navigation';
+  import GlassCard from '$lib/components/GlassCard.svelte';
+  import Button from '$lib/components/Button.svelte';
+  import { apiFetch } from '$lib/utils/apiUtils';
+
+  let orgId = '';
+  let email = '';
+  let password = '';
+  let error: string | null = null;
+  let success: string | null = null;
+
+  async function submit() {
+    error = null;
+    success = null;
+    try {
+      const res = await apiFetch('/api/register', {
+        method: 'POST',
+        body: JSON.stringify({ org_id: orgId, email, password })
+      });
+      if (res.ok) {
+        success = 'Registration successful. Please check your email to confirm.';
+      } else {
+        const data = await res.json().catch(() => ({ error: 'Registration failed' }));
+        error = data.error || 'Registration failed';
+      }
+    } catch (e: any) {
+      error = e.message || 'Registration failed';
+    }
+  }
+</script>
+
+<div class="min-h-screen flex items-center justify-center p-4">
+  <GlassCard padding="p-6" customClass="w-full max-w-md text-center space-y-4">
+    <h1 class="text-2xl font-semibold mb-2">Register</h1>
+    <form class="space-y-4" on:submit|preventDefault={submit}>
+      <input class="glass-input w-full" type="text" bind:value={orgId} placeholder="Organization ID" required />
+      <input class="glass-input w-full" type="email" bind:value={email} placeholder="Email" required />
+      <input class="glass-input w-full" type="password" bind:value={password} placeholder="Password" required />
+      {#if error}
+        <p class="text-red-500 text-sm">{error}</p>
+      {/if}
+      {#if success}
+        <p class="text-green-500 text-sm">{success}</p>
+      {/if}
+      <Button type="submit" variant="primary" customClass="w-full">Register</Button>
+    </form>
+    <p class="text-sm">Already have an account? <a href="/login" class="text-accent hover:underline">Login</a></p>
+  </GlassCard>
+</div>


### PR DESCRIPTION
## Summary
- add `/login` and `/register` routes
- hook forms to backend via `apiFetch`
- use `apiFetch` in `LoginForm` component
- update placeholder links to real login page

## Testing
- `npm test --prefix frontend`

------
https://chatgpt.com/codex/tasks/task_e_6864389444a883338db4c43e406a249e