### PR TITLE
Add endpoint URL validation

### DIFF
--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -38,6 +38,7 @@ regex = "1" # Added for parse stage processing
 pulldown-cmark = "0.9" # For Markdown to PDF report generation
 jsonpath-rust = "1.0.2"  # For extracting summary fields in report stage
 sanitize-filename = "0.1" # For sanitizing original filenames for S3 keys
+url = "2"
 log = "0.4"
 async-trait = "0.1"
 

--- a/backend/src/handlers/settings.rs
+++ b/backend/src/handlers/settings.rs
@@ -1,12 +1,16 @@
-use actix_web::{get, post, web, HttpResponse};
-use uuid::Uuid;
 use crate::middleware::auth::AuthUser;
 use crate::models::OrgSettings;
+use actix_web::{get, post, web, HttpResponse};
 use sqlx::PgPool;
-
+use url::Url;
+use uuid::Uuid;
 
 #[get("/settings/{org_id}")]
-async fn get_settings(path: web::Path<Uuid>, user: AuthUser, pool: web::Data<PgPool>) -> HttpResponse {
+async fn get_settings(
+    path: web::Path<Uuid>,
+    user: AuthUser,
+    pool: web::Data<PgPool>,
+) -> HttpResponse {
     let org_id_from_path = *path;
 
     // Authorization: Global admin can view any org's settings.
@@ -16,32 +20,48 @@ async fn get_settings(path: web::Path<Uuid>, user: AuthUser, pool: web::Data<PgP
             "Unauthorized attempt to access settings for org {} by user {} (role: {}, user_org: {})",
             org_id_from_path, user.user_id, user.role, user.org_id
         );
-        return HttpResponse::Unauthorized().json(serde_json::json!({"error": "You are not authorized to view these settings."}));
+        return HttpResponse::Unauthorized()
+            .json(serde_json::json!({"error": "You are not authorized to view these settings."}));
     }
 
     match OrgSettings::find(&pool, org_id_from_path).await {
-        Ok(mut settings) => { // Make settings mutable for masking
+        Ok(mut settings) => {
+            // Make settings mutable for masking
             // Mask sensitive API keys before sending to frontend
-            if settings.ai_api_key.as_ref().map_or(false, |k| !k.is_empty()) {
+            if settings
+                .ai_api_key
+                .as_ref()
+                .map_or(false, |k| !k.is_empty())
+            {
                 settings.ai_api_key = Some("********".to_string());
             }
-            if settings.ocr_api_key.as_ref().map_or(false, |k| !k.is_empty()) {
+            if settings
+                .ocr_api_key
+                .as_ref()
+                .map_or(false, |k| !k.is_empty())
+            {
                 settings.ocr_api_key = Some("********".to_string());
             }
             // Other sensitive fields could be masked here in the future
 
             HttpResponse::Ok().json(settings)
-        },
+        }
         Err(sqlx::Error::RowNotFound) => {
             log::info!("Settings not found for org {}. A new default might be created on next update or implicitly.", org_id_from_path);
             // Depending on product requirements, this could return default settings instead of 404.
             // For now, if no settings row exists, it's treated as "not found".
             // Org creation should ideally create default settings record.
-            HttpResponse::NotFound().json(serde_json::json!({"error": "Settings not found for this organization."}))
+            HttpResponse::NotFound()
+                .json(serde_json::json!({"error": "Settings not found for this organization."}))
         }
         Err(e) => {
-            log::error!("Failed to retrieve settings for org {}: {:?}", org_id_from_path, e);
-            HttpResponse::InternalServerError().json(serde_json::json!({"error": "Failed to retrieve settings."}))
+            log::error!(
+                "Failed to retrieve settings for org {}: {:?}",
+                org_id_from_path,
+                e
+            );
+            HttpResponse::InternalServerError()
+                .json(serde_json::json!({"error": "Failed to retrieve settings."}))
         }
     }
 }
@@ -61,15 +81,17 @@ async fn update_settings(
             "Unauthorized attempt to update settings for org {} by user {} (role: {}, user_org: {})",
             incoming_settings.org_id, user.user_id, user.role, user.org_id
         );
-        return HttpResponse::Unauthorized().json(serde_json::json!({"error": "You are not authorized to update these settings."}));
+        return HttpResponse::Unauthorized().json(
+            serde_json::json!({"error": "You are not authorized to update these settings."}),
+        );
     }
     // Also, a non-admin user should not be able to change their org_id via the payload to something else.
     // The incoming_settings.org_id must match user.org_id if not admin.
     if user.role != "admin" && incoming_settings.org_id != user.org_id {
-         // This check is somewhat redundant due to the one above, but emphasizes that org_id in payload must be theirs.
-        return HttpResponse::BadRequest().json(serde_json::json!({"error": "Invalid organization ID in request."}));
+        // This check is somewhat redundant due to the one above, but emphasizes that org_id in payload must be theirs.
+        return HttpResponse::BadRequest()
+            .json(serde_json::json!({"error": "Invalid organization ID in request."}));
     }
-
 
     // Fetch current settings from DB to preserve keys if "********" is sent
     let current_settings = match OrgSettings::find(&pool, incoming_settings.org_id).await {
@@ -83,7 +105,11 @@ async fn update_settings(
             return HttpResponse::NotFound().json(serde_json::json!({"error": "Settings for the specified organization not found. Cannot update."}));
         }
         Err(e) => {
-            log::error!("Failed to fetch current settings for org {}: {:?}", incoming_settings.org_id, e);
+            log::error!(
+                "Failed to fetch current settings for org {}: {:?}",
+                incoming_settings.org_id,
+                e
+            );
             return HttpResponse::InternalServerError().json(serde_json::json!({"error": "Could not retrieve current settings to safely update API keys."}));
         }
     };
@@ -101,15 +127,37 @@ async fn update_settings(
         incoming_settings.ocr_api_key = current_settings.ocr_api_key;
     }
 
+    // Validate endpoint URLs if provided
+    if let Some(ref endpoint) = incoming_settings.ai_api_endpoint {
+        if !endpoint.is_empty() && Url::parse(endpoint).is_err() {
+            return HttpResponse::BadRequest()
+                .json(serde_json::json!({"error": "Invalid AI API endpoint."}));
+        }
+    }
+    if let Some(ref endpoint) = incoming_settings.ocr_api_endpoint {
+        if !endpoint.is_empty() && Url::parse(endpoint).is_err() {
+            return HttpResponse::BadRequest()
+                .json(serde_json::json!({"error": "Invalid OCR API endpoint."}));
+        }
+    }
+
     // Now, incoming_settings contains the new values, or original values for keys if "********" was passed.
     match OrgSettings::update(&pool, incoming_settings).await {
         Ok(updated_settings_from_db) => {
             // Mask API keys again before sending back the updated settings in the response
             let mut response_settings = updated_settings_from_db;
-            if response_settings.ai_api_key.as_ref().map_or(false, |k| !k.is_empty()) {
+            if response_settings
+                .ai_api_key
+                .as_ref()
+                .map_or(false, |k| !k.is_empty())
+            {
                 response_settings.ai_api_key = Some("********".to_string());
             }
-            if response_settings.ocr_api_key.as_ref().map_or(false, |k| !k.is_empty()) {
+            if response_settings
+                .ocr_api_key
+                .as_ref()
+                .map_or(false, |k| !k.is_empty())
+            {
                 response_settings.ocr_api_key = Some("********".to_string());
             }
             HttpResponse::Ok().json(response_settings)
@@ -121,8 +169,13 @@ async fn update_settings(
             // Since `incoming_settings` is moved, we should ideally log `current_settings.org_id`
             // or ensure `incoming_settings.org_id` is cloned before move for logging.
             // For now, let's use `current_settings.org_id` for this log message.
-            log::error!("Failed to update settings for org {}: {:?}", current_settings.org_id, e);
-            HttpResponse::InternalServerError().json(serde_json::json!({"error": "Failed to update settings."}))
+            log::error!(
+                "Failed to update settings for org {}: {:?}",
+                current_settings.org_id,
+                e
+            );
+            HttpResponse::InternalServerError()
+                .json(serde_json::json!({"error": "Failed to update settings."}))
         }
     }
 }

--- a/backend/tests/settings_tests.rs
+++ b/backend/tests/settings_tests.rs
@@ -1,12 +1,14 @@
-use actix_web::{test, http::header};
+use actix_web::{http::header, test};
 use serde_json::json;
 
 mod test_utils;
-use test_utils::{setup_test_app, create_org, create_user, generate_jwt_token};
+use test_utils::{create_org, create_user, generate_jwt_token, setup_test_app};
 
 #[actix_rt::test]
 async fn test_get_settings_success() {
-    let Ok((app, pool)) = setup_test_app().await else { return; };
+    let Ok((app, pool)) = setup_test_app().await else {
+        return;
+    };
     let org_id = create_org(&pool, "Settings Org").await;
     let user_id = create_user(&pool, org_id, "admin@example.com", "org_admin").await;
     let token = generate_jwt_token(user_id, org_id, "org_admin");
@@ -23,7 +25,9 @@ async fn test_get_settings_success() {
 
 #[actix_rt::test]
 async fn test_update_settings_success() {
-    let Ok((app, pool)) = setup_test_app().await else { return; };
+    let Ok((app, pool)) = setup_test_app().await else {
+        return;
+    };
     let org_id = create_org(&pool, "Update Org").await;
     let user_id = create_user(&pool, org_id, "admin@example.com", "org_admin").await;
     let token = generate_jwt_token(user_id, org_id, "org_admin");
@@ -43,17 +47,20 @@ async fn test_update_settings_success() {
     assert!(resp.status().is_success());
     let updated: serde_json::Value = test::read_body_json(resp).await;
     assert_eq!(updated["monthly_upload_quota"], 150);
-    let row: (i32,) = sqlx::query_as("SELECT monthly_upload_quota FROM org_settings WHERE org_id=$1")
-        .bind(org_id)
-        .fetch_one(&pool)
-        .await
-        .unwrap();
+    let row: (i32,) =
+        sqlx::query_as("SELECT monthly_upload_quota FROM org_settings WHERE org_id=$1")
+            .bind(org_id)
+            .fetch_one(&pool)
+            .await
+            .unwrap();
     assert_eq!(row.0, 150);
 }
 
 #[actix_rt::test]
 async fn test_update_settings_invalid_quota() {
-    let Ok((app, pool)) = setup_test_app().await else { return; };
+    let Ok((app, pool)) = setup_test_app().await else {
+        return;
+    };
     let org_id = create_org(&pool, "Bad Quota Org").await;
     let user_id = create_user(&pool, org_id, "admin@example.com", "org_admin").await;
     let token = generate_jwt_token(user_id, org_id, "org_admin");
@@ -61,6 +68,56 @@ async fn test_update_settings_invalid_quota() {
     let payload = json!({
         "org_id": org_id,
         "monthly_upload_quota": -1,
+        "monthly_analysis_quota": 10,
+        "accent_color": "#123456"
+    });
+    let req = test::TestRequest::post()
+        .uri("/api/settings")
+        .insert_header((header::AUTHORIZATION, format!("Bearer {}", token)))
+        .set_json(&payload)
+        .to_request();
+    let resp = test::call_service(&app, req).await;
+    assert_eq!(resp.status(), actix_web::http::StatusCode::BAD_REQUEST);
+}
+
+#[actix_rt::test]
+async fn test_update_settings_invalid_ai_endpoint() {
+    let Ok((app, pool)) = setup_test_app().await else {
+        return;
+    };
+    let org_id = create_org(&pool, "Bad AI Endpoint Org").await;
+    let user_id = create_user(&pool, org_id, "admin@example.com", "org_admin").await;
+    let token = generate_jwt_token(user_id, org_id, "org_admin");
+
+    let payload = json!({
+        "org_id": org_id,
+        "ai_api_endpoint": "not-a-valid-url",
+        "monthly_upload_quota": 10,
+        "monthly_analysis_quota": 10,
+        "accent_color": "#123456"
+    });
+    let req = test::TestRequest::post()
+        .uri("/api/settings")
+        .insert_header((header::AUTHORIZATION, format!("Bearer {}", token)))
+        .set_json(&payload)
+        .to_request();
+    let resp = test::call_service(&app, req).await;
+    assert_eq!(resp.status(), actix_web::http::StatusCode::BAD_REQUEST);
+}
+
+#[actix_rt::test]
+async fn test_update_settings_invalid_ocr_endpoint() {
+    let Ok((app, pool)) = setup_test_app().await else {
+        return;
+    };
+    let org_id = create_org(&pool, "Bad OCR Endpoint Org").await;
+    let user_id = create_user(&pool, org_id, "admin@example.com", "org_admin").await;
+    let token = generate_jwt_token(user_id, org_id, "org_admin");
+
+    let payload = json!({
+        "org_id": org_id,
+        "ocr_api_endpoint": "http:/missing-slashes",
+        "monthly_upload_quota": 10,
         "monthly_analysis_quota": 10,
         "accent_color": "#123456"
     });


### PR DESCRIPTION
## Summary
- validate AI/OCR endpoint URLs in `update_settings`
- return BadRequest on invalid URL strings
- add unit tests for invalid AI/OCR endpoints
- add `url` crate for URL parsing

## Testing
- `cargo test --manifest-path backend/Cargo.toml --all-targets` *(fails: Failed to connect to test database)*

------
https://chatgpt.com/codex/tasks/task_e_68657367b6148333b064dba013a25b6a