### PR TITLE
Include document and pipeline names in job list

### DIFF
--- a/backend/src/models/mod.rs
+++ b/backend/src/models/mod.rs
@@ -1,17 +1,17 @@
-pub mod user;
-pub mod organization;
-pub mod settings;
-pub mod document;
-pub mod pipeline;
 pub mod analysis_job;
 pub mod audit_log;
-pub mod job_stage_output; // Added new module
+pub mod document;
+pub mod job_stage_output;
+pub mod organization;
+pub mod pipeline;
+pub mod settings;
+pub mod user; // Added new module
 
-pub use user::{User, NewUser};
-pub use organization::{Organization, NewOrganization};
-pub use settings::{OrgSettings, NewOrgSettings};
-pub use document::{Document, NewDocument};
-pub use pipeline::{Pipeline, NewPipeline};
-pub use analysis_job::{AnalysisJob, NewAnalysisJob};
+pub use analysis_job::{AnalysisJob, JobWithNames, NewAnalysisJob};
 pub use audit_log::{AuditLog, NewAuditLog};
-pub use job_stage_output::{JobStageOutput, NewJobStageOutput}; // Added new pub use
+pub use document::{Document, NewDocument};
+pub use job_stage_output::{JobStageOutput, NewJobStageOutput};
+pub use organization::{NewOrganization, Organization};
+pub use pipeline::{NewPipeline, Pipeline};
+pub use settings::{NewOrgSettings, OrgSettings};
+pub use user::{NewUser, User}; // Added new pub use

--- a/backend/tests/job_list_tests.rs
+++ b/backend/tests/job_list_tests.rs
@@ -1,0 +1,64 @@
+use actix_web::{http::header, test};
+use serde_json::json;
+
+mod test_utils;
+use backend::models::{AnalysisJob, Document, NewAnalysisJob, NewDocument, NewPipeline, Pipeline};
+use test_utils::{create_org, create_user, generate_jwt_token, setup_test_app};
+use uuid::Uuid;
+
+#[actix_rt::test]
+async fn list_jobs_includes_names() {
+    let Ok((app, pool)) = setup_test_app().await else {
+        return;
+    };
+    let org_id = create_org(&pool, "Job Org").await;
+    let user_id = create_user(&pool, org_id, "user@example.com", "org_admin").await;
+    let _token = generate_jwt_token(user_id, org_id, "org_admin");
+
+    let pipeline = Pipeline::create(
+        &pool,
+        NewPipeline {
+            org_id,
+            name: "Pipe".into(),
+            stages: json!([]),
+        },
+    )
+    .await
+    .unwrap();
+    let document = Document::create(
+        &pool,
+        NewDocument {
+            org_id,
+            owner_id: user_id,
+            filename: "f.pdf".into(),
+            pages: 1,
+            is_target: true,
+            expires_at: None,
+            display_name: "File.pdf".into(),
+        },
+    )
+    .await
+    .unwrap();
+    let _job = AnalysisJob::create(
+        &pool,
+        NewAnalysisJob {
+            org_id,
+            document_id: document.id,
+            pipeline_id: pipeline.id,
+            status: "pending".into(),
+        },
+    )
+    .await
+    .unwrap();
+
+    let req = test::TestRequest::get()
+        .uri(&format!("/api/jobs/{}", org_id))
+        .to_request();
+    let resp = test::call_service(&app, req).await;
+    assert!(resp.status().is_success());
+    let list: serde_json::Value = test::read_body_json(resp).await;
+    assert_eq!(list.as_array().unwrap().len(), 1);
+    let first = &list[0];
+    assert_eq!(first["document_name"], "File.pdf");
+    assert_eq!(first["pipeline_name"], "Pipe");
+}

--- a/frontend/src/lib/components/JobsList.svelte
+++ b/frontend/src/lib/components/JobsList.svelte
@@ -14,8 +14,8 @@
     pipeline_id: string; // UUID
     status: string;
     created_at: string; // ISO date string
-    document_name?: string; // Will be placeholder for now
-    pipeline_name?: string; // Will be placeholder for now
+    document_name: string;
+    pipeline_name: string;
     // Any other fields from AnalysisJob that might be useful
   }
   export let jobs: Job[] = [];
@@ -43,8 +43,8 @@
     ...job,
     // Format for sortability and readability: YYYY-MM-DD HH:MM:SS
     created_at_formatted: new Date(job.created_at).toISOString().replace('T', ' ').substring(0, 19),
-    document_name: job.document_name || `Doc: ${job.document_id.substring(0,8)}...`, // Shortened placeholder prefix
-    pipeline_name: job.pipeline_name || `Pipe: ${job.pipeline_id.substring(0,8)}...`, // Shortened placeholder prefix
+    document_name: job.document_name,
+    pipeline_name: job.pipeline_name,
   })).sort((a, b) => new Date(b.created_at).getTime() - new Date(a.created_at).getTime()); // Initial sort
 
   let sources: ReconnectingEventSource[] = [];

--- a/frontend/src/lib/components/__tests__/JobsList.test.ts
+++ b/frontend/src/lib/components/__tests__/JobsList.test.ts
@@ -1,0 +1,24 @@
+import { render } from '@testing-library/svelte';
+import { expect, test, vi } from 'vitest';
+import JobsList from '../JobsList.svelte';
+
+const now = new Date().toISOString();
+
+test('shows provided document and pipeline names', () => {
+  vi.stubGlobal('EventSource', class { close() {} } as any);
+  const jobs = [
+    {
+      id: 'j1',
+      org_id: 'o1',
+      document_id: 'd1',
+      pipeline_id: 'p1',
+      status: 'pending',
+      created_at: now,
+      document_name: 'Doc.pdf',
+      pipeline_name: 'MyPipe',
+    },
+  ];
+  const { getByText } = render(JobsList, { props: { jobs } });
+  expect(getByText('Doc.pdf')).toBeInTheDocument();
+  expect(getByText('MyPipe')).toBeInTheDocument();
+});


### PR DESCRIPTION
## Summary
- extend `AnalysisJob` with `JobWithNames` struct and query logic
- export new struct via model module
- return document and pipeline names from job listing handler
- display names in `JobsList` component
- add backend integration test
- add unit test for `JobsList` component

## Testing
- `cargo test --manifest-path backend/Cargo.toml --quiet` *(fails: PoolTimedOut)*
- `npm run lint --prefix frontend` *(fails with Svelte errors)*
- `npm test --prefix frontend --silent` *(fails: 1 test failed)*
- `npm run build --prefix frontend` *(fails: ParseError)*

------
https://chatgpt.com/codex/tasks/task_e_6866d8fc3a088333a86cec3b6b2ab907