### PR TITLE
Add Docker release workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,8 +12,8 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
-          node-version: 20 # Matches existing setup
-      - name: Install Rust toolchain # Explicitly add this for clarity
+          node-version: 20
+      - name: Install Rust toolchain
         uses: actions/setup-rust@v1
         with:
           rust-version: stable
@@ -22,12 +22,51 @@ jobs:
       - name: Install frontend deps
         run: npm install --prefix frontend
       - name: Svelte Check
-        run: npm run lint --prefix frontend # Changed from npx svelte-check...
+        run: npm run lint --prefix frontend
       - name: Run frontend tests
         run: npm test --prefix frontend
       - name: Build frontend
-        run: npm run build --prefix frontend # This can also serve as a test that the build passes
-      - name: Check backend (Clippy) # Modified Step
+        run: npm run build --prefix frontend
+      - name: Check backend (Clippy)
         run: cargo clippy --manifest-path backend/Cargo.toml --all-targets -- --deny warnings
+
+  backend-tests:
+    needs: build
+    strategy:
+      matrix:
+        os: [ubuntu-latest, windows-latest, macos-latest]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-rust@v1
+        with:
+          rust-version: stable
       - name: Run backend tests
         run: cargo test --manifest-path backend/Cargo.toml --all-targets
+
+  release:
+    needs: [build, backend-tests]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Build backend image
+        run: docker build -t backend:latest -f backend/Dockerfile .
+      - name: Build frontend image
+        run: docker build -t frontend:latest -f frontend/Dockerfile .
+      - name: Log in to registry
+        if: ${{ secrets.REGISTRY != '' }}
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ secrets.REGISTRY }}
+          username: ${{ secrets.REGISTRY_USERNAME }}
+          password: ${{ secrets.REGISTRY_PASSWORD }}
+      - name: Push backend image
+        if: ${{ secrets.REGISTRY != '' }}
+        run: |
+          docker tag backend:latest ${{ secrets.REGISTRY }}/backend:latest
+          docker push ${{ secrets.REGISTRY }}/backend:latest
+      - name: Push frontend image
+        if: ${{ secrets.REGISTRY != '' }}
+        run: |
+          docker tag frontend:latest ${{ secrets.REGISTRY }}/frontend:latest
+          docker push ${{ secrets.REGISTRY }}/frontend:latest

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ Multi-tenant document analysis platform built with Rust and Svelte.
 - [Setup](docs/Setup.md)
 - [Security](docs/Security.md)
 - [Continuous Integration](docs/Continuous_Integration.md)
+- [Deployment](docs/Deployment.md)
 
 See [PLAN.md](PLAN.md) for the project roadmap.
 

--- a/docs/Deployment.md
+++ b/docs/Deployment.md
@@ -1,0 +1,11 @@
+# Deployment
+
+The project ships with a GitHub Actions workflow that can build Docker images for the backend and frontend. The `release` job in `.github/workflows/ci.yml` runs after all tests succeed.
+
+## Release workflow
+1. CI installs dependencies, lints and runs unit tests for the frontend.
+2. The `backend-tests` matrix job executes `cargo test` on `ubuntu-latest`, `windows-latest` and `macos-latest`.
+3. When every job succeeds, `release` builds container images using the provided Dockerfiles.
+4. If repository secrets `REGISTRY`, `REGISTRY_USERNAME` and `REGISTRY_PASSWORD` are set, the job logs in and pushes the images to that registry.
+
+The resulting images are tagged as `backend:latest` and `frontend:latest`. Use a tag strategy that fits your deployment pipeline or add additional steps to push versioned tags.


### PR DESCRIPTION
## Summary
- build backend on ubuntu
- test backend across ubuntu, windows and macos
- release job builds docker images and optionally pushes them
- document deployment process
- link deployment docs from README

## Testing
- `cargo test --manifest-path backend/Cargo.toml --all-targets` *(fails: Failed to connect to test database)*
- `npm install --prefix frontend`
- `npm test --prefix frontend` *(fails: vitest found failing tests)*

------
https://chatgpt.com/codex/tasks/task_e_6866ddccebfc8333be08122f99783f10