### PR TITLE
Add startup env var checks

### DIFF
--- a/backend/tests/env_var_check.rs
+++ b/backend/tests/env_var_check.rs
@@ -1,0 +1,13 @@
+use std::process::Command;
+
+#[test]
+fn missing_env_vars_cause_error() {
+    let mut cmd = Command::new(env!("CARGO_BIN_EXE_backend"));
+    cmd.env_remove("DATABASE_URL");
+    cmd.env("JWT_SECRET", "secret");
+    cmd.env("S3_BUCKET", "uploads");
+    let output = cmd.output().expect("run backend binary");
+    assert!(!output.status.success());
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(stderr.contains("DATABASE_URL"));
+}


### PR DESCRIPTION
## Summary
- ensure required environment variables are present before starting server
- exit with a helpful error when variables are missing
- test backend binary exits when variables are missing

## Testing
- `cargo test --manifest-path backend/Cargo.toml missing_env_vars_cause_error -- --nocapture`

------
https://chatgpt.com/codex/tasks/task_e_6866e51a20c483338b5b000c837c5c62