### PR TITLE
Add more env var failure tests

### DIFF
--- a/backend/tests/env_var_check.rs
+++ b/backend/tests/env_var_check.rs
@@ -11,3 +11,26 @@ fn missing_env_vars_cause_error() {
     let stderr = String::from_utf8_lossy(&output.stderr);
     assert!(stderr.contains("DATABASE_URL"));
 }
+#[test]
+fn missing_jwt_secret_causes_error() {
+    let mut cmd = Command::new(env!("CARGO_BIN_EXE_backend"));
+    cmd.env("DATABASE_URL", "postgres://user:pass@localhost/db");
+    cmd.env_remove("JWT_SECRET");
+    cmd.env("S3_BUCKET", "uploads");
+    let output = cmd.output().expect("run backend binary");
+    assert!(!output.status.success());
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(stderr.contains("JWT_SECRET"));
+}
+
+#[test]
+fn missing_s3_bucket_causes_error() {
+    let mut cmd = Command::new(env!("CARGO_BIN_EXE_backend"));
+    cmd.env("DATABASE_URL", "postgres://user:pass@localhost/db");
+    cmd.env("JWT_SECRET", "secret");
+    cmd.env_remove("S3_BUCKET");
+    let output = cmd.output().expect("run backend binary");
+    assert!(!output.status.success());
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(stderr.contains("S3_BUCKET"));
+}


### PR DESCRIPTION
## Summary
- add extra test cases for missing critical env vars

## Testing
- `cargo test --test env_var_check`
- `cargo test` *(fails: Failed to connect to test database)*

------
https://chatgpt.com/codex/tasks/task_e_6866e72dd720833387fb11f97907b519