### PR TITLE
Fix PipelineEditor placeholder test

### DIFF
--- a/frontend/src/lib/components/__tests__/PipelineEditor.test.ts
+++ b/frontend/src/lib/components/__tests__/PipelineEditor.test.ts
@@ -102,7 +102,7 @@ test("renders delimiter regex field for table extraction", async () => {
   await tick();
 
   expect(
-    getByPlaceholderText("optional, defaults to whitespace or '|"),
+    getByPlaceholderText("optional, defaults to whitespace or '|'"),
   ).toBeTruthy();
   expect(getByText("Generate Numeric Summary")).toBeTruthy();
 });


### PR DESCRIPTION
## Summary
- fix placeholder string in `PipelineEditor.test.ts`

## Testing
- `npx vitest run`
- `cargo test --manifest-path backend/Cargo.toml` *(fails: Failed to connect to test database: PoolTimedOut)*

------
https://chatgpt.com/codex/tasks/task_e_6866e919de70833383ebdf382543ec85