### PR TITLE
Add custom sanitization error

### DIFF
--- a/backend/src/models/mod.rs
+++ b/backend/src/models/mod.rs
@@ -9,7 +9,7 @@ pub mod user; // Added new module
 
 pub use analysis_job::{AnalysisJob, JobWithNames, NewAnalysisJob};
 pub use audit_log::{AuditLog, NewAuditLog};
-pub use document::{Document, NewDocument};
+pub use document::{Document, NewDocument, DocumentError};
 pub use job_stage_output::{JobStageOutput, NewJobStageOutput};
 pub use organization::{NewOrganization, Organization};
 pub use pipeline::{NewPipeline, Pipeline};


### PR DESCRIPTION
## Summary
- define `DocumentError` for document creation issues
- return the new error from `Document::create`
- surface sanitization failures as HTTP 400 in the upload handler

## Testing
- `cargo check --manifest-path backend/Cargo.toml`
- `cargo test --manifest-path backend/Cargo.toml` *(fails: PoolTimedOut)*

------
https://chatgpt.com/codex/tasks/task_e_6867a6ba97e8833393087d464ff6a0a2