### PR TITLE
Refactor handler errors to ApiError

### DIFF
--- a/backend/src/handlers/audit.rs
+++ b/backend/src/handlers/audit.rs
@@ -1,4 +1,5 @@
-use actix_web::{get, web, HttpResponse};
+use actix_web::{get, web, HttpResponse, http::StatusCode, ResponseError};
+use crate::error::ApiError;
 use sqlx::PgPool;
 use uuid::Uuid;
 use crate::middleware::auth::AuthUser;
@@ -7,11 +8,13 @@ use crate::models::AuditLog;
 #[get("/audit/{org_id}")]
 async fn list_logs(path: web::Path<Uuid>, user: AuthUser, pool: web::Data<PgPool>) -> HttpResponse {
     if *path != user.org_id {
-        return HttpResponse::Unauthorized().finish();
+        return ApiError::new("Unauthorized", StatusCode::UNAUTHORIZED)
+            .error_response();
     }
     match AuditLog::list_by_org(pool.as_ref(), *path).await {
         Ok(list) => HttpResponse::Ok().json(list),
-        Err(_) => HttpResponse::InternalServerError().finish(),
+        Err(_) => ApiError::new("Failed to retrieve logs", StatusCode::INTERNAL_SERVER_ERROR)
+            .error_response(),
     }
 }
 

--- a/backend/src/handlers/job.rs
+++ b/backend/src/handlers/job.rs
@@ -1,6 +1,7 @@
 use crate::middleware::auth::AuthUser;
 use crate::models::{AnalysisJob, Document, JobStageOutput, Pipeline};
-use actix_web::{get, web, HttpResponse};
+use actix_web::{get, web, HttpResponse, http::StatusCode, ResponseError};
+use crate::error::ApiError;
 use actix_web_lab::sse::{self, ChannelStream, Sse};
 use aws_sdk_s3::presigning::PresigningConfig;
 use serde::Serialize;
@@ -34,7 +35,8 @@ struct JobDetailsResponse {
 async fn list_jobs(path: web::Path<Uuid>, pool: web::Data<PgPool>) -> HttpResponse {
     match AnalysisJob::find_by_org(pool.as_ref(), *path).await {
         Ok(list) => HttpResponse::Ok().json(list),
-        Err(_) => HttpResponse::InternalServerError().finish(),
+        Err(_) => ApiError::new("Failed to list jobs", StatusCode::INTERNAL_SERVER_ERROR)
+            .error_response(),
     }
 }
 

--- a/backend/tests/admin_invite_tests.rs
+++ b/backend/tests/admin_invite_tests.rs
@@ -51,6 +51,8 @@ async fn test_admin_invite_invalid_email() {
 
     let resp = test::call_service(&app, req).await;
     assert_eq!(resp.status(), actix_web::http::StatusCode::BAD_REQUEST);
+    let body: serde_json::Value = test::read_body_json(resp).await;
+    assert!(body.get("error").is_some());
 }
 
 #[actix_rt::test]
@@ -71,6 +73,8 @@ async fn test_admin_invite_unauthorized() {
 
     let resp = test::call_service(&app, req).await;
     assert_eq!(resp.status(), actix_web::http::StatusCode::FORBIDDEN);
+    let body: serde_json::Value = test::read_body_json(resp).await;
+    assert!(body.get("error").is_some());
 }
 
 #[actix_rt::test]
@@ -93,4 +97,6 @@ async fn test_admin_invite_duplicate_email() {
 
     let resp = test::call_service(&app, req).await;
     assert_eq!(resp.status(), actix_web::http::StatusCode::CONFLICT);
+    let body: serde_json::Value = test::read_body_json(resp).await;
+    assert!(body.get("error").is_some());
 }

--- a/backend/tests/admin_role_tests.rs
+++ b/backend/tests/admin_role_tests.rs
@@ -43,6 +43,8 @@ async fn test_non_admin_cannot_assign_role() {
         .to_request();
     let resp = test::call_service(&app, req).await;
     assert_eq!(resp.status(), actix_web::http::StatusCode::FORBIDDEN);
+    let body: serde_json::Value = test::read_body_json(resp).await;
+    assert!(body.get("error").is_some());
 }
 
 #[actix_rt::test]
@@ -85,6 +87,8 @@ async fn test_assign_org_admin_with_invalid_org() {
         .to_request();
     let resp = test::call_service(&app, req).await;
     assert_eq!(resp.status(), actix_web::http::StatusCode::BAD_REQUEST);
+    let body: serde_json::Value = test::read_body_json(resp).await;
+    assert!(body.get("error").is_some());
 }
 
 // These tests require a PostgreSQL instance pointed to by `DATABASE_URL_TEST`.

--- a/backend/tests/document_tests.rs
+++ b/backend/tests/document_tests.rs
@@ -111,6 +111,8 @@ async fn test_pdf_upload_bad_content_type() {
         .to_request();
     let resp = test::call_service(&app, req).await;
     assert_eq!(resp.status(), actix_web::http::StatusCode::BAD_REQUEST);
+    let body: serde_json::Value = test::read_body_json(resp).await;
+    assert!(body.get("error").is_some());
     let count: (i64,) = sqlx::query_as("SELECT COUNT(*) FROM documents WHERE org_id=$1")
         .bind(org_id)
         .fetch_one(&pool)
@@ -155,6 +157,8 @@ async fn test_cleanup_on_failed_upload() {
         .to_request();
     let resp = test::call_service(&app, req).await;
     assert_eq!(resp.status(), actix_web::http::StatusCode::INTERNAL_SERVER_ERROR);
+    let body: serde_json::Value = test::read_body_json(resp).await;
+    assert!(body.get("error").is_some());
     assert_eq!(put_mock.received_requests().await.len(), 1);
     assert_eq!(delete_mock.received_requests().await.len(), 1);
 }

--- a/backend/tests/org_management_tests.rs
+++ b/backend/tests/org_management_tests.rs
@@ -78,6 +78,8 @@ async fn test_get_organization_users_as_unauthorized_user() {
 
     let resp = test::call_service(&app, req).await;
     assert_eq!(resp.status(), actix_web::http::StatusCode::FORBIDDEN);
+    let body: serde_json::Value = test::read_body_json(resp).await;
+    assert!(body.get("error").is_some());
 }
 
 #[actix_rt::test]
@@ -159,6 +161,8 @@ async fn test_remove_user_from_organization_unauthorized() {
         .to_request();
     let resp = test::call_service(&app, req).await;
     assert_eq!(resp.status(), actix_web::http::StatusCode::FORBIDDEN);
+    let body: serde_json::Value = test::read_body_json(resp).await;
+    assert!(body.get("error").is_some());
 }
 
 #[actix_rt::test]
@@ -210,4 +214,6 @@ async fn test_resend_confirmation_email_org_user_unauthorized() {
         .to_request();
     let resp = test::call_service(&app, req).await;
     assert_eq!(resp.status(), actix_web::http::StatusCode::FORBIDDEN);
+    let body: serde_json::Value = test::read_body_json(resp).await;
+    assert!(body.get("error").is_some());
 }

--- a/backend/tests/pipeline_tests.rs
+++ b/backend/tests/pipeline_tests.rs
@@ -46,6 +46,8 @@ async fn test_reject_missing_stage_type() {
         .to_request();
     let resp = test::call_service(&app, req).await;
     assert_eq!(resp.status(), actix_web::http::StatusCode::BAD_REQUEST);
+    let body: serde_json::Value = test::read_body_json(resp).await;
+    assert!(body.get("error").is_some());
 }
 
 #[actix_rt::test]
@@ -66,6 +68,8 @@ async fn test_reject_empty_pipeline_name() {
         .to_request();
     let resp = test::call_service(&app, req).await;
     assert_eq!(resp.status(), actix_web::http::StatusCode::BAD_REQUEST);
+    let body: serde_json::Value = test::read_body_json(resp).await;
+    assert!(body.get("error").is_some());
 }
 
 #[actix_rt::test]
@@ -143,6 +147,8 @@ async fn test_update_pipeline_other_org_unauthorized() {
         .to_request();
     let resp = test::call_service(&app, req).await;
     assert_eq!(resp.status(), actix_web::http::StatusCode::UNAUTHORIZED);
+    let body: serde_json::Value = test::read_body_json(resp).await;
+    assert!(body.get("error").is_some());
 }
 
 #[actix_rt::test]
@@ -211,6 +217,8 @@ async fn test_delete_pipeline_other_org_unauthorized() {
         .to_request();
     let resp = test::call_service(&app, req).await;
     assert_eq!(resp.status(), actix_web::http::StatusCode::UNAUTHORIZED);
+    let body: serde_json::Value = test::read_body_json(resp).await;
+    assert!(body.get("error").is_some());
 }
 
 #[actix_rt::test]
@@ -234,6 +242,8 @@ async fn test_reject_duplicate_stage_ids() {
         .to_request();
     let resp = test::call_service(&app, req).await;
     assert_eq!(resp.status(), actix_web::http::StatusCode::BAD_REQUEST);
+    let body: serde_json::Value = test::read_body_json(resp).await;
+    assert!(body.get("error").is_some());
 }
 
 

--- a/backend/tests/settings_tests.rs
+++ b/backend/tests/settings_tests.rs
@@ -78,6 +78,8 @@ async fn test_update_settings_invalid_quota() {
         .to_request();
     let resp = test::call_service(&app, req).await;
     assert_eq!(resp.status(), actix_web::http::StatusCode::BAD_REQUEST);
+    let body: serde_json::Value = test::read_body_json(resp).await;
+    assert!(body.get("error").is_some());
 }
 
 #[actix_rt::test]
@@ -103,6 +105,8 @@ async fn test_update_settings_invalid_ai_endpoint() {
         .to_request();
     let resp = test::call_service(&app, req).await;
     assert_eq!(resp.status(), actix_web::http::StatusCode::BAD_REQUEST);
+    let body: serde_json::Value = test::read_body_json(resp).await;
+    assert!(body.get("error").is_some());
 }
 
 #[actix_rt::test]
@@ -128,4 +132,6 @@ async fn test_update_settings_invalid_ocr_endpoint() {
         .to_request();
     let resp = test::call_service(&app, req).await;
     assert_eq!(resp.status(), actix_web::http::StatusCode::BAD_REQUEST);
+    let body: serde_json::Value = test::read_body_json(resp).await;
+    assert!(body.get("error").is_some());
 }


### PR DESCRIPTION
## Summary
- refactor several handlers to create error responses via `ApiError`
- update tests to check consistent `{ "error": ... }` responses

## Testing
- `cargo test --quiet` *(fails: Failed to connect to test database)*

------
https://chatgpt.com/codex/tasks/task_e_6867a6bc16dc8333986656fcc0ddb98b