### PR TITLE
Improve ApiError use

### DIFF
--- a/backend/src/handlers/pipeline.rs
+++ b/backend/src/handlers/pipeline.rs
@@ -197,7 +197,8 @@ async fn create_pipeline(data: web::Json<PipelineInput>, user: AuthUser, pool: w
         Ok(p) => HttpResponse::Ok().json(p),
         Err(e) => {
             log::error!("Failed to create pipeline for org_id {}: {:?}", data.org_id, e);
-            HttpResponse::InternalServerError().json(serde_json::json!({"error": "Failed to create pipeline."}))
+            ApiError::new("Failed to create pipeline", StatusCode::INTERNAL_SERVER_ERROR)
+                .error_response()
         }
     }
 }

--- a/backend/src/handlers/settings.rs
+++ b/backend/src/handlers/settings.rs
@@ -60,8 +60,8 @@ async fn get_settings(
                 org_id_from_path,
                 e
             );
-            HttpResponse::InternalServerError()
-                .json(serde_json::json!({"error": "Failed to retrieve settings."}))
+            ApiError::new("Failed to retrieve settings", StatusCode::INTERNAL_SERVER_ERROR)
+                .error_response()
         }
     }
 }
@@ -110,7 +110,11 @@ async fn update_settings(
                 incoming_settings.org_id,
                 e
             );
-            return HttpResponse::InternalServerError().json(serde_json::json!({"error": "Could not retrieve current settings to safely update API keys."}));
+            return ApiError::new(
+                "Could not retrieve current settings to safely update API keys",
+                StatusCode::INTERNAL_SERVER_ERROR,
+            )
+            .error_response();
         }
     };
 
@@ -174,8 +178,8 @@ async fn update_settings(
                 current_settings.org_id,
                 e
             );
-            HttpResponse::InternalServerError()
-                .json(serde_json::json!({"error": "Failed to update settings."}))
+            ApiError::new("Failed to update settings", StatusCode::INTERNAL_SERVER_ERROR)
+                .error_response()
         }
     }
 }


### PR DESCRIPTION
## Summary
- refine internal server error responses for pipelines and org settings

## Testing
- `cargo test --manifest-path backend/Cargo.toml` *(fails: unclosed delimiter in `document.rs`)*

------
https://chatgpt.com/codex/tasks/task_e_6867b9dfbe54833395fcfdcf15cffaa0