### PR TITLE
Add CSRF header middleware

### DIFF
--- a/backend/src/handlers/settings.rs
+++ b/backend/src/handlers/settings.rs
@@ -1,6 +1,7 @@
 use crate::middleware::auth::AuthUser;
 use crate::models::OrgSettings;
-use actix_web::{get, post, web, HttpResponse};
+use crate::error::ApiError;
+use actix_web::{get, post, web, HttpResponse, http::StatusCode, ResponseError};
 use sqlx::PgPool;
 use url::Url;
 use uuid::Uuid;

--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -9,7 +9,11 @@ use std::env;
 use backend::config::AppConfig;
 
 use backend::handlers;
-use backend::middleware::{jwt::init_jwt_secret, rate_limit::RateLimit};
+use backend::middleware::{
+    jwt::init_jwt_secret,
+    rate_limit::RateLimit,
+    csrf_check::{CsrfCheck, init_csrf_token},
+};
 
 #[actix_web::main]
 async fn main() -> std::io::Result<()> {
@@ -22,6 +26,7 @@ async fn main() -> std::io::Result<()> {
     };
     std::env::set_var("JWT_SECRET", &config.jwt_secret);
     init_jwt_secret();
+    init_csrf_token();
     tracing_subscriber::fmt::init();
 
     let database_url = config.database_url;
@@ -52,6 +57,7 @@ async fn main() -> std::io::Result<()> {
             .wrap(Logger::default())
             .wrap(cors)
             .wrap(RateLimit)
+            .wrap(CsrfCheck)
             .wrap(prometheus.clone())
             .app_data(web::Data::new(pool.clone()))
             .app_data(web::Data::new(s3_client.clone()))

--- a/backend/src/middleware/csrf_check.rs
+++ b/backend/src/middleware/csrf_check.rs
@@ -1,0 +1,63 @@
+use actix_service::{Service, Transform, forward_ready};
+use actix_web::{dev::{ServiceRequest, ServiceResponse}, Error, http::header::HeaderName};
+use futures_util::future::{LocalBoxFuture, ready, Ready};
+use once_cell::sync::Lazy;
+use std::{env, rc::Rc};
+
+static CSRF_TOKEN: Lazy<Option<String>> = Lazy::new(|| env::var("CSRF_TOKEN").ok());
+const CSRF_HEADER: HeaderName = HeaderName::from_static("x-csrf-token");
+
+pub fn init_csrf_token() {
+    Lazy::force(&CSRF_TOKEN);
+}
+
+pub struct CsrfCheck;
+
+impl<S, B> Transform<S, ServiceRequest> for CsrfCheck
+where
+    S: Service<ServiceRequest, Response = ServiceResponse<B>, Error = Error> + 'static,
+    B: 'static,
+{
+    type Response = ServiceResponse<B>;
+    type Error = Error;
+    type Transform = CsrfCheckMiddleware<S>;
+    type InitError = ();
+    type Future = Ready<Result<Self::Transform, Self::InitError>>;
+
+    fn new_transform(&self, service: S) -> Self::Future {
+        ready(Ok(CsrfCheckMiddleware { service: Rc::new(service) }))
+    }
+}
+
+pub struct CsrfCheckMiddleware<S> {
+    service: Rc<S>,
+}
+
+impl<S, B> Service<ServiceRequest> for CsrfCheckMiddleware<S>
+where
+    S: Service<ServiceRequest, Response = ServiceResponse<B>, Error = Error> + 'static,
+    B: 'static,
+{
+    type Response = ServiceResponse<B>;
+    type Error = Error;
+    type Future = LocalBoxFuture<'static, Result<Self::Response, Self::Error>>;
+
+    forward_ready!(service);
+
+    fn call(&self, req: ServiceRequest) -> Self::Future {
+        let srv = Rc::clone(&self.service);
+        let token = req
+            .headers()
+            .get(&CSRF_HEADER)
+            .and_then(|v| v.to_str().ok())
+            .map(|s| s.to_string());
+        Box::pin(async move {
+            if let Some(expected) = CSRF_TOKEN.as_ref() {
+                if token.as_deref() != Some(expected.as_str()) {
+                    return Err(actix_web::error::ErrorForbidden("Invalid CSRF token"));
+                }
+            }
+            srv.call(req).await
+        })
+    }
+}

--- a/backend/src/middleware/mod.rs
+++ b/backend/src/middleware/mod.rs
@@ -1,3 +1,4 @@
 pub mod jwt;
 pub mod auth;
 pub mod rate_limit;
+pub mod csrf_check;

--- a/backend/tests/csrf_check.rs
+++ b/backend/tests/csrf_check.rs
@@ -1,0 +1,56 @@
+use actix_web::{test, App};
+use backend::handlers;
+use backend::middleware::csrf_check::CsrfCheck;
+
+#[actix_rt::test]
+async fn rejects_missing_token() {
+    std::env::set_var("CSRF_TOKEN", "secret");
+    let app = test::init_service(
+        App::new()
+            .wrap(CsrfCheck)
+            .configure(handlers::health::routes),
+    )
+    .await;
+
+    let req = test::TestRequest::get().uri("/health").to_request();
+    let resp = test::try_call_service(&app, req).await;
+    let err = resp.expect_err("expected csrf error");
+    assert_eq!(err.as_response_error().status_code(), actix_web::http::StatusCode::FORBIDDEN);
+}
+
+#[actix_rt::test]
+async fn rejects_invalid_token() {
+    std::env::set_var("CSRF_TOKEN", "secret");
+    let app = test::init_service(
+        App::new()
+            .wrap(CsrfCheck)
+            .configure(handlers::health::routes),
+    )
+    .await;
+
+    let req = test::TestRequest::get()
+        .uri("/health")
+        .insert_header(("X-CSRF-Token", "wrong"))
+        .to_request();
+    let resp = test::try_call_service(&app, req).await;
+    let err = resp.expect_err("expected csrf error");
+    assert_eq!(err.as_response_error().status_code(), actix_web::http::StatusCode::FORBIDDEN);
+}
+
+#[actix_rt::test]
+async fn accepts_valid_token() {
+    std::env::set_var("CSRF_TOKEN", "secret");
+    let app = test::init_service(
+        App::new()
+            .wrap(CsrfCheck)
+            .configure(handlers::health::routes),
+    )
+    .await;
+
+    let req = test::TestRequest::get()
+        .uri("/health")
+        .insert_header(("X-CSRF-Token", "secret"))
+        .to_request();
+    let resp = test::call_service(&app, req).await;
+    assert!(resp.status().is_success());
+}


### PR DESCRIPTION
## Summary
- add `CsrfCheck` middleware verifying `X-CSRF-Token`
- register the middleware in `main.rs`
- fix missing imports in `settings.rs`
- test CSRF middleware behaviour

## Testing
- `cargo test --test csrf_check -- --test-threads=1`

------
https://chatgpt.com/codex/tasks/task_e_68681aa8c77c83338585a86179af1241