### PR TITLE
Implement email retry with audit log

### DIFF
--- a/backend/src/handlers/admin/invites.rs
+++ b/backend/src/handlers/admin/invites.rs
@@ -4,7 +4,7 @@ use sqlx::PgPool;
 use uuid::Uuid;
 use crate::middleware::auth::AuthUser;
 use crate::models::{User as UserModel, NewUser};
-use crate::email::send_email;
+use crate::email::send_email_retry;
 use argon2::{Argon2, PasswordHasher};
 use argon2::password_hash::SaltString;
 use rand::Rng;
@@ -77,7 +77,7 @@ pub async fn invite_user(
                 "Hello,\n\nYou have been invited to join crPipeline. Click the link below to confirm your account:\n{}\n",
                 confirmation_link
             );
-            if let Err(e) = send_email(&email, email_subject, &email_body).await {
+            if let Err(e) = send_email_retry(&pool, admin.org_id, admin.user_id, &email, email_subject, &email_body, 3).await {
                 log::error!("Failed to send invite email to {}: {:?}", email, e);
                 HttpResponse::Accepted().json(serde_json::json!({
                     "success": true,

--- a/backend/src/handlers/org/invites.rs
+++ b/backend/src/handlers/org/invites.rs
@@ -3,7 +3,7 @@ use serde::Deserialize;
 use sqlx::PgPool;
 use crate::models::{User as UserModel, NewUser};
 use crate::middleware::auth::AuthUser;
-use crate::email::send_email;
+use crate::email::send_email_retry;
 use argon2::{Argon2, PasswordHasher};
 use argon2::password_hash::SaltString;
 use rand::Rng;
@@ -99,7 +99,7 @@ The crPipeline Team"#,
                 target_email, org_name, confirmation_link
             );
 
-            if let Err(e) = send_email(&target_email, &email_subject, &email_body).await {
+            if let Err(e) = send_email_retry(&pool, current_org_admin.org_id, current_org_admin.user_id, &target_email, &email_subject, &email_body, 3).await {
                 log::error!("User {} created by org_admin {}, but failed to send confirmation email to {}: {:?}", created_user.id, current_org_admin.user_id, target_email, e);
                 return HttpResponse::Accepted().json(serde_json::json!({
                     "success": true,

--- a/backend/src/handlers/settings.rs
+++ b/backend/src/handlers/settings.rs
@@ -1,6 +1,8 @@
 use crate::middleware::auth::AuthUser;
 use crate::models::OrgSettings;
-use actix_web::{get, post, web, HttpResponse};
+use actix_web::{get, post, web, HttpResponse, ResponseError};
+use crate::error::ApiError;
+use actix_web::http::StatusCode;
 use sqlx::PgPool;
 use url::Url;
 use uuid::Uuid;


### PR DESCRIPTION
## Summary
- add `send_email_retry` to centralize retry logic and audit logging
- log failed email attempts in audit logs
- switch handlers to call `send_email_retry`
- fix missing imports in settings handler

## Testing
- `cargo test` *(fails: Failed to connect to test database)*

------
https://chatgpt.com/codex/tasks/task_e_68681ab250f48333a85575fcf0c4e88c