### PR TITLE
Add tests for parse regex and report templating

### DIFF
--- a/backend/tests/parse_regex.rs
+++ b/backend/tests/parse_regex.rs
@@ -1,0 +1,69 @@
+use backend::processing::run_parse_stage;
+use serde_json::json;
+use uuid::Uuid;
+
+mod test_utils;
+use test_utils::generate_jwt_token;
+
+#[actix_rt::test]
+async fn regex_extraction_basic() {
+    let token = generate_jwt_token(Uuid::new_v4(), Uuid::new_v4(), "user");
+    let text = format!("User token: {} Email: user@example.com", token);
+    let config = json!({
+        "strategy": "regexExtraction",
+        "parameters": {
+            "patterns": [
+                {"name": "token", "regex": r"([A-Za-z0-9-_]+\.[A-Za-z0-9-_]+\.[A-Za-z0-9-_]+)"},
+                {"name": "email", "regex": r"[\w.-]+@[\w.-]+"}
+            ]
+        }
+    });
+    let res = run_parse_stage(&text, Some(&config)).await.unwrap();
+    assert_eq!(res["email"][0], "user@example.com");
+    assert_eq!(res["token"][0], token);
+}
+
+#[actix_rt::test]
+async fn regex_capture_group_index() {
+    let text = "Total: 42";
+    let config = json!({
+        "strategy": "regexExtraction",
+        "parameters": {
+            "patterns": [
+                {"name": "total", "regex": r"Total:\s+(\d+)", "captureGroupIndex": 1}
+            ]
+        }
+    });
+    let res = run_parse_stage(text, Some(&config)).await.unwrap();
+    assert_eq!(res["total"][0], "42");
+}
+
+#[actix_rt::test]
+async fn regex_capture_group_out_of_bounds() {
+    let text = "Value: 99";
+    let config = json!({
+        "strategy": "regexExtraction",
+        "parameters": {
+            "patterns": [
+                {"name": "val", "regex": r"Value:\s+(\d+)", "captureGroupIndex": 2}
+            ]
+        }
+    });
+    let res = run_parse_stage(text, Some(&config)).await.unwrap();
+    assert_eq!(res["val"][0], "Value: 99");
+}
+
+#[actix_rt::test]
+async fn regex_invalid_pattern() {
+    let text = "abc";
+    let config = json!({
+        "strategy": "regexExtraction",
+        "parameters": {
+            "patterns": [
+                {"name": "bad", "regex": "([a-z"}
+            ]
+        }
+    });
+    let res = run_parse_stage(text, Some(&config)).await.unwrap();
+    assert!(res["bad"][0].as_str().unwrap().contains("Regex Compile Error"));
+}

--- a/backend/tests/report_template_summary.rs
+++ b/backend/tests/report_template_summary.rs
@@ -1,0 +1,43 @@
+use backend::processing::generate_report_from_template;
+use serde_json::json;
+use lopdf::Document as PdfDoc;
+use uuid::Uuid;
+
+mod test_utils;
+use test_utils::generate_jwt_token;
+
+#[actix_rt::test]
+async fn placeholder_nested() {
+    let token = generate_jwt_token(Uuid::new_v4(), Uuid::new_v4(), "user");
+    let md = "## Info\nToken: {{auth.token}}";
+    let data = json!({"document_name": "Doc", "auth": {"token": token}});
+    let tmp = tempfile::NamedTempFile::new().unwrap();
+    generate_report_from_template(md, &data, tmp.path()).await.unwrap();
+    let pdf = PdfDoc::load(tmp.path()).unwrap();
+    let text = pdf.extract_text(&[1]).unwrap();
+    assert!(text.contains(&token));
+}
+
+#[actix_rt::test]
+async fn placeholder_jsonpath() {
+    let md = "First item: {{summary.section.sub.value}}";
+    let data = json!({
+        "document_name": "Items",
+        "summary": {"section": {"sub": {"value": "Apple"}}}
+    });
+    let tmp = tempfile::NamedTempFile::new().unwrap();
+    generate_report_from_template(md, &data, tmp.path()).await.unwrap();
+    let pdf = PdfDoc::load(tmp.path()).unwrap();
+    let text = pdf.extract_text(&[1]).unwrap();
+    assert!(text.contains("Apple"));
+}
+
+#[actix_rt::test]
+async fn invalid_output_path() {
+    let md = "Hi";
+    let data = json!({"document_name": "Doc"});
+    let dir = tempfile::tempdir().unwrap();
+    let bad_path = dir.path().join("missing").join("out.pdf");
+    let res = generate_report_from_template(md, &data, &bad_path).await;
+    assert!(res.is_err());
+}


### PR DESCRIPTION
## Summary
- add coverage for RegexExtraction parsing
- test capture group edge cases and invalid patterns
- test generate_report_from_template with nested placeholders and invalid paths

## Testing
- `cargo test --test parse_regex -- --nocapture`
- `cargo test --test report_template_summary -- --nocapture`

------
https://chatgpt.com/codex/tasks/task_e_686826548df48333b9940842ecd4ef45