### PR TITLE
Add non-root app user in backend Dockerfile

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -4,11 +4,14 @@ COPY backend ./
 RUN cargo build --release
 
 FROM debian:bullseye-slim
-RUN apt-get update && apt-get install -y ca-certificates && rm -rf /var/lib/apt/lists/*
+RUN apt-get update && apt-get install -y ca-certificates && rm -rf /var/lib/apt/lists/* \
+    && useradd -m app
 WORKDIR /app
 COPY --from=build /app/target/release/backend /usr/local/bin/backend
 COPY --from=build /app/target/release/worker /usr/local/bin/worker
 COPY --from=build /app/target/release/cleanup /usr/local/bin/cleanup
 COPY backend/migrations ./migrations
+RUN chown -R app:app /app
+USER app
 ENV RUST_LOG=info
 CMD ["backend"]


### PR DESCRIPTION
## Summary
- run backend image under a dedicated `app` user

## Testing
- `docker compose build backend` *(fails: `docker` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68683d1b4c5c83339d1eb794aad53e41