### PR TITLE
Add Playwright e2e tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,6 +27,12 @@ jobs:
         run: npm test --prefix frontend
       - name: Build frontend
         run: npm run build --prefix frontend
+      - name: Install Playwright browsers
+        run: npx playwright install --with-deps
+        working-directory: frontend
+      - name: Run e2e tests
+        run: npm run e2e
+        working-directory: frontend
       - name: Check backend (Clippy)
         run: cargo clippy --manifest-path backend/Cargo.toml --all-targets -- --deny warnings
       - name: Run migrations

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -11,6 +11,7 @@
         "chart.js": "^4.3.0"
       },
       "devDependencies": {
+        "@playwright/test": "^1.39.0",
         "@sveltejs/vite-plugin-svelte": "^2.0.0",
         "@testing-library/jest-dom": "^6.0.0",
         "@testing-library/svelte": "^4.0.0",
@@ -607,6 +608,22 @@
       "optional": true,
       "engines": {
         "node": ">=14"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.53.2",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.53.2.tgz",
+      "integrity": "sha512-tEB2U5z74ebBeyfGNZ3Jfg29AnW+5HlWhvHtb/Mqco9pFdZU1ZLNdVb2UtB5CvmiilNr2ZfVH/qMmAROG/XTzw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.53.2"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@sinclair/typebox": {
@@ -3426,6 +3443,53 @@
       "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/playwright": {
+      "version": "1.53.2",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.53.2.tgz",
+      "integrity": "sha512-6K/qQxVFuVQhRQhFsVZ9fGeatxirtrpPgxzBYWyZLEXJzqYwuL4fuNmfOfD5et1tJE4GScKyPNeLhZeRwuTU3A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.53.2"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.53.2",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.53.2.tgz",
+      "integrity": "sha512-ox/OytMy+2w1jcYEYlOo1Hhp8hZkLCximMTUTMBXjGUA1KoFfiSZ+DU+3a739jsPY0yoKH2TFy9S2fsJas8yAw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
     },
     "node_modules/possible-typed-array-names": {
       "version": "1.1.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -7,7 +7,8 @@
     "build": "vite build",
     "preview": "vite preview",
     "test": "vitest",
-    "lint": "svelte-check --tsconfig ./tsconfig.json"
+    "lint": "svelte-check --tsconfig ./tsconfig.json",
+    "e2e": "playwright test"
   },
   "devDependencies": {
     "@sveltejs/vite-plugin-svelte": "^2.0.0",
@@ -23,7 +24,8 @@
     "typescript": "^5.1.3",
     "vite": "^4.3.9",
     "vitest": "^0.34.6",
-    "@testing-library/jest-dom": "^6.0.0"
+    "@testing-library/jest-dom": "^6.0.0",
+    "@playwright/test": "^1.39.0"
   },
   "dependencies": {
     "chart.js": "^4.3.0"

--- a/frontend/playwright.config.ts
+++ b/frontend/playwright.config.ts
@@ -1,0 +1,15 @@
+import { defineConfig } from '@playwright/test';
+
+export default defineConfig({
+  testDir: './tests/e2e',
+  timeout: 30000,
+  use: {
+    baseURL: 'http://localhost:4173',
+    headless: true
+  },
+  webServer: {
+    command: 'npm run preview -- --port 4173',
+    port: 4173,
+    reuseExistingServer: !process.env.CI
+  }
+});

--- a/frontend/tests/e2e/login-pipeline.spec.ts
+++ b/frontend/tests/e2e/login-pipeline.spec.ts
@@ -1,0 +1,62 @@
+import { test, expect } from '@playwright/test';
+
+// This test mocks backend endpoints to exercise the login flow
+// and the pipeline editor in the built application.
+
+test('login and create pipeline', async ({ page }) => {
+  // Initial checkAuth request should respond with 401 to show login page
+  await page.route('**/api/me', route => {
+    const isAuthCheck = route.request().method() === 'GET';
+    route.fulfill({ status: isAuthCheck ? 401 : 200, body: '{}' });
+  });
+
+  // Mock login endpoint
+  await page.route('**/api/login', route => {
+    route.fulfill({ status: 200, body: '{}' });
+  });
+
+  // After login, /api/me should return session info
+  await page.route('**/api/me', route => {
+    route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({ org_id: 'testorg', user_id: 'user', role: 'admin' })
+    });
+  });
+
+  // Pipelines API
+  await page.route('**/api/pipelines/testorg', route => {
+    route.fulfill({ status: 200, contentType: 'application/json', body: '[]' });
+  });
+  await page.route('**/api/pipelines', route => {
+    if (route.request().method() === 'POST') {
+      route.fulfill({ status: 200, body: '{}' });
+    } else {
+      route.continue();
+    }
+  });
+
+  // Open login page
+  await page.goto('/login');
+  await page.fill('input[type="email"]', 'user@example.com');
+  await page.fill('input[type="password"]', 'password');
+  await page.click('text=Login');
+
+  // Wait for redirect to dashboard after login
+  await page.waitForURL('/dashboard');
+
+  // Navigate to pipelines page
+  await page.goto('/pipelines');
+  await page.click('text=Create New Pipeline');
+
+  await page.fill('input[placeholder="Pipeline name"]', 'My Pipeline');
+  await page.fill('input[placeholder="New Stage Type"]', 'parse');
+  await page.click('text=Add Stage');
+
+  const [req] = await Promise.all([
+    page.waitForRequest(request => request.url().includes('/api/pipelines') && request.method() === 'POST'),
+    page.click('text=Save')
+  ]);
+
+  expect(req.method()).toBe('POST');
+});

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -16,6 +16,7 @@ export default defineConfig({
     environment: 'jsdom',
     globals: true,
     transformMode: { web: [/\.svelte$/] },
-    setupFiles: './vitest.setup.ts'
+    setupFiles: './vitest.setup.ts',
+    exclude: ['tests/e2e/**']
   }
 });


### PR DESCRIPTION
## Summary
- set up Playwright test runner
- add e2e test for login and pipeline editor
- ignore e2e files in Vitest config
- run Playwright tests in CI after the frontend build

## Testing
- `npm test --prefix frontend` *(fails: auto-cleanup-skip, mount tests, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68683d19557c83338e5f834aca5c8572