### PR TITLE
Improve error handling in processing

### DIFF
--- a/backend/tests/parse_stage.rs
+++ b/backend/tests/parse_stage.rs
@@ -47,3 +47,17 @@ async fn test_numeric_summary() {
     assert_eq!(summary["qty"]["sum"], 3.0);
     assert_eq!(summary["price"]["sum"], 6.0);
 }
+
+#[actix_rt::test]
+async fn test_invalid_delimiter_regex_does_not_panic() {
+    let text = "HEADER\nItem Qty\nApple 1";
+    let config = json!({
+        "strategy": "SimpleTableExtraction",
+        "parameters": {
+            "headerKeywords": ["item", "qty"],
+            "delimiterRegex": "(*invalid"
+        }
+    });
+    let res = run_parse_stage(text, Some(&config)).await;
+    assert!(res.is_ok());
+}


### PR DESCRIPTION
## Summary
- avoid panic-causing unwraps in `processing.rs`
- add test ensuring invalid delimiter regex doesn't panic

## Testing
- `cargo test test_invalid_delimiter_regex_does_not_panic -- --nocapture`

------
https://chatgpt.com/codex/tasks/task_e_68683d17a5348333aba9096104a572c4