### PR TITLE
Add readiness endpoint and probes

### DIFF
--- a/backend/src/handlers/health.rs
+++ b/backend/src/handlers/health.rs
@@ -1,10 +1,31 @@
-use actix_web::{get, HttpResponse, Responder};
+use actix_web::{get, web, HttpResponse, Responder};
+use sqlx::PgPool;
+use aws_sdk_s3::Client as S3Client;
 
 #[get("/health")]
 pub async fn health() -> impl Responder {
     HttpResponse::Ok().body("ok")
 }
 
+#[get("/readiness")]
+pub async fn readiness(
+    pool: web::Data<PgPool>,
+    s3: web::Data<S3Client>,
+) -> impl Responder {
+    let db_ok = sqlx::query("SELECT 1")
+        .execute(pool.as_ref())
+        .await
+        .is_ok();
+
+    let s3_ok = s3.list_buckets().send().await.is_ok();
+
+    if db_ok && s3_ok {
+        HttpResponse::Ok().finish()
+    } else {
+        HttpResponse::ServiceUnavailable().finish()
+    }
+}
+
 pub fn routes(cfg: &mut actix_web::web::ServiceConfig) {
-    cfg.service(health);
+    cfg.service(health).service(readiness);
 }

--- a/backend/tests/readiness.rs
+++ b/backend/tests/readiness.rs
@@ -1,0 +1,41 @@
+use actix_web::{test, web, App, http::StatusCode};
+use backend::handlers;
+use sqlx::postgres::PgPoolOptions;
+use wiremock::{MockServer, Mock, ResponseTemplate};
+use wiremock::matchers::method;
+use aws_config::meta::region::RegionProviderChain;
+use aws_sdk_s3::Client as S3Client;
+
+#[actix_rt::test]
+async fn readiness_unavailable_without_db() {
+    let s3_server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .respond_with(ResponseTemplate::new(200))
+        .mount(&s3_server)
+        .await;
+
+    std::env::set_var("AWS_ACCESS_KEY_ID", "test");
+    std::env::set_var("AWS_SECRET_ACCESS_KEY", "test");
+    let region_provider = RegionProviderChain::default_provider().or_else("us-east-1");
+    let shared_config = aws_config::from_env().region(region_provider).load().await;
+    let s3_config = aws_sdk_s3::config::Builder::from(&shared_config)
+        .endpoint_url(s3_server.uri())
+        .force_path_style(true)
+        .build();
+    let s3_client = S3Client::from_conf(s3_config);
+
+    let pool = PgPoolOptions::new()
+        .connect_lazy("postgres://user@localhost/db")
+        .unwrap();
+
+    let app = test::init_service(
+        App::new()
+            .app_data(web::Data::new(pool))
+            .app_data(web::Data::new(s3_client))
+            .configure(handlers::health::routes)
+    ).await;
+
+    let req = test::TestRequest::get().uri("/readiness").to_request();
+    let resp = test::call_service(&app, req).await;
+    assert_eq!(resp.status(), StatusCode::SERVICE_UNAVAILABLE);
+}

--- a/k8s/backend-deployment.yaml
+++ b/k8s/backend-deployment.yaml
@@ -20,6 +20,18 @@ spec:
             name: backend-env
         ports:
         - containerPort: 8080
+        livenessProbe:
+          httpGet:
+            path: /api/health
+            port: 8080
+          initialDelaySeconds: 5
+          periodSeconds: 10
+        readinessProbe:
+          httpGet:
+            path: /api/readiness
+            port: 8080
+          initialDelaySeconds: 5
+          periodSeconds: 10
 ---
 apiVersion: v1
 kind: Service


### PR DESCRIPTION
## Summary
- implement `/api/readiness` endpoint checking DB and S3
- register liveness and readiness probes in backend deployment
- add regression test for readiness handler

## Testing
- `cargo test --test readiness -- --test-threads=1`

------
https://chatgpt.com/codex/tasks/task_e_6868f753c1cc8333988fdce88eecaf7a