### PR TITLE
Fix compile warnings

### DIFF
--- a/backend/src/handlers/admin/user_management.rs
+++ b/backend/src/handlers/admin/user_management.rs
@@ -137,7 +137,6 @@ pub async fn assign_user_role(
             .json(serde_json::json!({"error": "Invalid role specified. Allowed roles are 'user' or 'org_admin'."}));
     }
 
-    let mut target_org_id_for_update: Option<Uuid> = None;
     if new_role == "org_admin" {
         match payload.org_id {
             Some(org_uuid) => {
@@ -146,8 +145,8 @@ pub async fn assign_user_role(
                     .fetch_one(pool.as_ref())
                     .await
                 {
-                    Ok(exists) if exists => target_org_id_for_update = Some(org_uuid),
-                    Ok(_) => {
+                    Ok(true) => {}
+                    Ok(false) => {
                         return HttpResponse::BadRequest()
                             .json(serde_json::json!({"error": format!("Organization with ID {} not found.", org_uuid)}));
                     }

--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -4,7 +4,6 @@ use actix_web_prom::PrometheusMetricsBuilder;
 use aws_config::meta::region::RegionProviderChain;
 use aws_sdk_s3::Client as S3Client;
 use sqlx::postgres::PgPoolOptions;
-use std::env;
 
 use backend::config::AppConfig;
 

--- a/backend/src/worker/mod.rs
+++ b/backend/src/worker/mod.rs
@@ -58,7 +58,7 @@ pub async fn upload_bytes(
                 .await
             {
                 Ok(_) => break Ok(()),
-                Err(e) if attempts < 3 => {
+                Err(_e) if attempts < 3 => {
                     S3_ERROR_COUNTER.with_label_values(&["upload"]).inc();
                     attempts += 1;
                     sleep(Duration::from_millis(500 * attempts as u64)).await;

--- a/backend/tests/audit_log_tests.rs
+++ b/backend/tests/audit_log_tests.rs
@@ -5,7 +5,6 @@ use test_utils::{create_org, create_user, generate_jwt_token};
 use sqlx::{PgPool, postgres::PgPoolOptions};
 use wiremock::{MockServer, Mock, ResponseTemplate};
 use wiremock::matchers::method;
-use uuid::Uuid;
 
 async fn setup_app(s3: &MockServer) -> (impl actix_web::dev::Service<actix_http::Request, Response = actix_web::dev::ServiceResponse, Error = actix_web::Error>, PgPool) {
     dotenvy::dotenv().ok();
@@ -25,7 +24,10 @@ async fn setup_app(s3: &MockServer) -> (impl actix_web::dev::Service<actix_http:
 #[actix_rt::test]
 async fn upload_creates_audit_log() {
     let s3_server = MockServer::start().await;
-    Mock::given(method("PUT")).respond_with(ResponseTemplate::new(200)).mount_as_scoped(&s3_server).await;
+    let _mock_guard = Mock::given(method("PUT"))
+        .respond_with(ResponseTemplate::new(200))
+        .mount_as_scoped(&s3_server)
+        .await;
 
     let (app, pool) = setup_app(&s3_server).await;
     let org_id = create_org(&pool, "Audit Org").await;

--- a/backend/tests/document_tests.rs
+++ b/backend/tests/document_tests.rs
@@ -177,7 +177,7 @@ async fn test_cleanup_on_failed_upload() {
 #[actix_rt::test]
 async fn reject_dangerous_filename() {
     let s3_server = MockServer::start().await;
-    let (app, pool) = setup_test_app(&s3_server).await;
+    let (_app, pool) = setup_test_app(&s3_server).await;
     let org_id = create_org(&pool, "Sanitize Org").await;
     let user_id = create_user(&pool, org_id, "san@example.com", "org_admin").await;
 

--- a/backend/tests/e2e_full_job.rs
+++ b/backend/tests/e2e_full_job.rs
@@ -8,7 +8,6 @@ use mini_redis::server;
 mod test_utils;
 use test_utils::{setup_test_app, create_org, create_user};
 use backend::models::{Pipeline, NewPipeline, Document, NewDocument, NewAnalysisJob, AnalysisJob};
-use uuid::Uuid;
 
 async fn start_redis() -> (oneshot::Sender<()>, u16) {
     let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();

--- a/backend/tests/e2e_job_errors.rs
+++ b/backend/tests/e2e_job_errors.rs
@@ -37,7 +37,7 @@ async fn ocr_error_marks_failed() {
     let tempdir = tempfile::tempdir().unwrap();
 
     let ocr_server = MockServer::start().await;
-    Mock::given(method("POST")).and(path("/ocr"))
+    let _ocr_mock = Mock::given(method("POST")).and(path("/ocr"))
         .respond_with(ResponseTemplate::new(500))
         .mount_as_scoped(&ocr_server)
         .await;
@@ -123,7 +123,7 @@ async fn ai_invalid_json_marks_failed() {
     let tempdir = tempfile::tempdir().unwrap();
 
     let ai_server = MockServer::start().await;
-    Mock::given(method("POST")).and(path("/ai"))
+    let _ai_mock = Mock::given(method("POST")).and(path("/ai"))
         .respond_with(ResponseTemplate::new(200).set_body_string("not-json"))
         .mount_as_scoped(&ai_server)
         .await;

--- a/backend/tests/e2e_job_flow.rs
+++ b/backend/tests/e2e_job_flow.rs
@@ -8,7 +8,6 @@ use mini_redis::server;
 mod test_utils;
 use test_utils::{setup_test_app, create_org, create_user};
 use backend::models::{Pipeline, NewPipeline, Document, NewDocument, NewAnalysisJob, AnalysisJob};
-use uuid::Uuid;
 
 async fn start_redis() -> (oneshot::Sender<()>, u16) {
     let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();

--- a/backend/tests/job_list_tests.rs
+++ b/backend/tests/job_list_tests.rs
@@ -1,10 +1,9 @@
-use actix_web::{http::header, test};
+use actix_web::test;
 use serde_json::json;
 
 mod test_utils;
 use backend::models::{AnalysisJob, Document, NewAnalysisJob, NewDocument, NewPipeline, Pipeline};
 use test_utils::{create_org, create_user, generate_jwt_token, setup_test_app};
-use uuid::Uuid;
 
 #[actix_rt::test]
 async fn list_jobs_includes_names() {


### PR DESCRIPTION
## Summary
- clean up unused variable check when updating org admin role
- mute S3 upload retry error variable
- drop unused env import
- fix tests for warnings

## Testing
- `cargo check --all-targets`

------
https://chatgpt.com/codex/tasks/task_e_6868f751ccd08333be308469c65a5517