### PR TITLE
Improve production security docs

### DIFF
--- a/docs/Deployment.md
+++ b/docs/Deployment.md
@@ -34,3 +34,7 @@ kubectl create secret generic frontend-env \
 ```
 
 Set the `REGISTRY` secret in your CI settings so images are pushed to your container registry.
+
+## TLS / HTTPS
+
+The backend itself does not terminate TLS. In production deploy it behind a reverse proxy or Kubernetes ingress that provides HTTPS. Configure `BASE_URL` and `FRONTEND_ORIGIN` with `https://` URLs so that login cookies receive the `Secure` flag and browsers enforce encrypted connections. Any ingress controller such as Nginx or Traefik can handle the certificates and forward traffic to the pod on port `8080`.

--- a/docs/Security.md
+++ b/docs/Security.md
@@ -5,3 +5,9 @@ All endpoints enforce JWT authentication and CORS restrictions via the `FRONTEND
 
 For production deployments generate unique credentials instead of relying on the example values in `backend/.env`. Run `scripts/generate_secrets.sh` to create `backend/.env.prod` with random keys. Review the generated file and provide your own database and service endpoints before starting the application.
 
+### Recommended production values
+
+- **`CSRF_TOKEN`** – set this to a high‑entropy random string such as the output of `openssl rand -hex 32`. When present the backend rejects requests whose `X-CSRF-Token` header does not match this value.
+- **Secure cookies** – the login cookie is flagged `HttpOnly` and `SameSite=Lax` by default. The `Secure` flag is automatically enabled when `BASE_URL` starts with `https://`. Ensure `BASE_URL` and `FRONTEND_ORIGIN` use HTTPS in production so cookies are transmitted only over TLS.
+- **Rate limiting** – provide a production Redis instance via `REDIS_URL`. Set `REDIS_RATE_LIMIT_FALLBACK=deny` so that API requests are rejected if Redis becomes unavailable instead of falling back to the in‑memory limiter.
+


### PR DESCRIPTION
## Summary
- document recommended CSRF token, cookies and rate limit settings
- add TLS/HTTPS deployment notes

## Testing
- `cargo test --manifest-path backend/Cargo.toml` *(fails: PoolTimedOut)*
- `npm install --prefix frontend`
- `npm test --prefix frontend`

------
https://chatgpt.com/codex/tasks/task_e_6868f754720483339e008a1141973b73