### PR TITLE
Enforce stronger JWT_SECRET

### DIFF
--- a/backend/src/config.rs
+++ b/backend/src/config.rs
@@ -13,8 +13,8 @@ impl AppConfig {
         dotenv().ok();
         let database_url = env::var("DATABASE_URL").map_err(|_| "DATABASE_URL not set".to_string())?;
         let jwt_secret = env::var("JWT_SECRET").map_err(|_| "JWT_SECRET not set".to_string())?;
-        if jwt_secret.len() < 32 {
-            return Err("JWT_SECRET must be at least 32 characters".into());
+        if jwt_secret.len() < 32 || jwt_secret == "changeme" {
+            return Err("JWT_SECRET must be at least 32 characters and not 'changeme'".into());
         }
         let s3_bucket = env::var("S3_BUCKET").map_err(|_| "S3_BUCKET not set".to_string())?;
         let frontend_origin = env::var("FRONTEND_ORIGIN").unwrap_or_else(|_| "*".into());

--- a/backend/tests/env_var_check.rs
+++ b/backend/tests/env_var_check.rs
@@ -4,7 +4,7 @@ use std::process::Command;
 fn missing_env_vars_cause_error() {
     let mut cmd = Command::new(env!("CARGO_BIN_EXE_backend"));
     cmd.env_remove("DATABASE_URL");
-    cmd.env("JWT_SECRET", "secret");
+    cmd.env("JWT_SECRET", "0123456789abcdef0123456789abcdef");
     cmd.env("S3_BUCKET", "uploads");
     let output = cmd.output().expect("run backend binary");
     assert!(!output.status.success());
@@ -36,10 +36,22 @@ fn short_jwt_secret_causes_error() {
 }
 
 #[test]
+fn changeme_jwt_secret_causes_error() {
+    let mut cmd = Command::new(env!("CARGO_BIN_EXE_backend"));
+    cmd.env("DATABASE_URL", "postgres://user:pass@localhost/db");
+    cmd.env("JWT_SECRET", "changeme");
+    cmd.env("S3_BUCKET", "uploads");
+    let output = cmd.output().expect("run backend binary");
+    assert!(!output.status.success());
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(stderr.contains("JWT_SECRET"));
+}
+
+#[test]
 fn missing_s3_bucket_causes_error() {
     let mut cmd = Command::new(env!("CARGO_BIN_EXE_backend"));
     cmd.env("DATABASE_URL", "postgres://user:pass@localhost/db");
-    cmd.env("JWT_SECRET", "secret");
+    cmd.env("JWT_SECRET", "0123456789abcdef0123456789abcdef");
     cmd.env_remove("S3_BUCKET");
     let output = cmd.output().expect("run backend binary");
     assert!(!output.status.success());

--- a/docs/Environment.md
+++ b/docs/Environment.md
@@ -5,7 +5,7 @@ The file `backend/.env` defines required settings:
 ```
 DATABASE_URL=postgres://postgres:postgres@localhost/db
 JWT_SECRET=changeme
-# Must be at least 32 characters in production
+# Replace with a value of at least 32 characters before starting
 AWS_ENDPOINT=http://localhost:9000
 AWS_ACCESS_KEY=minioadmin
 AWS_SECRET_KEY=minioadmin


### PR DESCRIPTION
## Summary
- reject startup when `JWT_SECRET` is shorter than 32 characters or still set to `changeme`
- update environment documentation
- expand env var tests to cover new requirement and use valid secrets

## Testing
- `cargo test --test env_var_check -- --test-threads=1`

------
https://chatgpt.com/codex/tasks/task_e_686911956a408333a9cd95899d3a87d0