### PR TITLE
Allow custom IMAGE_TAG in CI build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,11 @@ on:
   push:
     branches: [main]
   pull_request:
+  workflow_dispatch:
+    inputs:
+      IMAGE_TAG:
+        description: 'Tag for Docker images'
+        required: false
 
 jobs:
   build:
@@ -71,12 +76,14 @@ jobs:
   release:
     needs: [build, backend-tests]
     runs-on: ubuntu-latest
+    env:
+      IMAGE_TAG: ${{ github.event.inputs.IMAGE_TAG || (startsWith(github.ref, 'refs/tags/') && github.ref_name) || 'latest' }}
     steps:
       - uses: actions/checkout@v3
       - name: Build backend image
-        run: docker build -t backend:latest -f backend/Dockerfile .
+        run: docker build -t backend:${{ env.IMAGE_TAG }} -f backend/Dockerfile .
       - name: Build frontend image
-        run: docker build -t frontend:latest -f frontend/Dockerfile .
+        run: docker build -t frontend:${{ env.IMAGE_TAG }} -f frontend/Dockerfile .
       - name: Log in to registry
         if: ${{ secrets.REGISTRY != '' }}
         uses: docker/login-action@v3
@@ -87,10 +94,10 @@ jobs:
       - name: Push backend image
         if: ${{ secrets.REGISTRY != '' }}
         run: |
-          docker tag backend:latest ${{ secrets.REGISTRY }}/backend:latest
-          docker push ${{ secrets.REGISTRY }}/backend:latest
+          docker tag backend:${{ env.IMAGE_TAG }} ${{ secrets.REGISTRY }}/backend:${{ env.IMAGE_TAG }}
+          docker push ${{ secrets.REGISTRY }}/backend:${{ env.IMAGE_TAG }}
       - name: Push frontend image
         if: ${{ secrets.REGISTRY != '' }}
         run: |
-          docker tag frontend:latest ${{ secrets.REGISTRY }}/frontend:latest
-          docker push ${{ secrets.REGISTRY }}/frontend:latest
+          docker tag frontend:${{ env.IMAGE_TAG }} ${{ secrets.REGISTRY }}/frontend:${{ env.IMAGE_TAG }}
+          docker push ${{ secrets.REGISTRY }}/frontend:${{ env.IMAGE_TAG }}

--- a/docs/Deployment.md
+++ b/docs/Deployment.md
@@ -8,7 +8,10 @@ The project ships with a GitHub Actions workflow that can build Docker images fo
 3. When every job succeeds, `release` builds container images using the provided Dockerfiles.
 4. If repository secrets `REGISTRY`, `REGISTRY_USERNAME` and `REGISTRY_PASSWORD` are set, the job logs in and pushes the images to that registry.
 
-The resulting images are tagged as `backend:latest` and `frontend:latest`. Use a tag strategy that fits your deployment pipeline or add additional steps to push versioned tags.
+The resulting images are tagged as `backend:$IMAGE_TAG` and `frontend:$IMAGE_TAG`.
+By default `IMAGE_TAG` is set to `latest`. When starting the workflow manually
+you can pass a Git tag or any other value as the `IMAGE_TAG` input to publish
+versioned images.
 
 ## Kubernetes Manifests
 


### PR DESCRIPTION
## Summary
- enable optional `IMAGE_TAG` input via `workflow_dispatch`
- build and push Docker images using the provided tag
- document the new variable in Deployment docs

## Testing
- `cargo test --all-targets` *(fails: Failed to connect to test database)*
- `npm test --prefix frontend` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68691196b8e483338e9a459a3e0c1495