### PR TITLE
Add global loading store for frontend

### DIFF
--- a/frontend/src/lib/components/GlobalLoadingIndicator.svelte
+++ b/frontend/src/lib/components/GlobalLoadingIndicator.svelte
@@ -1,8 +1,11 @@
 <script lang="ts">
-  export let loading: boolean = false;
+  import { derived } from 'svelte/store';
+  import { loadingStore } from '$lib/utils/loadingStore';
+
+  const isLoading = derived(loadingStore, (count) => count > 0);
 </script>
 
-{#if loading}
+{#if $isLoading}
   <div class="fixed top-0 left-0 right-0 h-1 z-[200]" role="progressbar" aria-valuetext="loading">
     <div class="h-full bg-accent animate-pulse rounded-r-full" style="width: 75%;"></div>
   </div>

--- a/frontend/src/lib/components/__tests__/GlobalLoadingIndicator.test.ts
+++ b/frontend/src/lib/components/__tests__/GlobalLoadingIndicator.test.ts
@@ -1,9 +1,23 @@
 import { render } from '@testing-library/svelte';
 import GlobalLoadingIndicator from '../GlobalLoadingIndicator.svelte';
+import { loadingStore } from '$lib/utils/loadingStore';
+import { tick } from 'svelte';
 import { expect, test } from 'vitest';
 
-test('renders progress bar when loading', () => {
-  const { getByRole } = render(GlobalLoadingIndicator, { props: { loading: true } });
-  expect(getByRole('progressbar')).toBeInTheDocument();
+test('reacts to loadingStore changes', async () => {
+  const { queryByRole } = render(GlobalLoadingIndicator);
+  expect(queryByRole('progressbar')).not.toBeInTheDocument();
+
+  loadingStore.start();
+  await tick();
+
+  expect(queryByRole('progressbar')).toBeInTheDocument();
+
+  loadingStore.end();
+  await tick();
+
+  expect(queryByRole('progressbar')).not.toBeInTheDocument();
+
+  loadingStore.reset();
 });
 

--- a/frontend/src/lib/utils/apiUtils.ts
+++ b/frontend/src/lib/utils/apiUtils.ts
@@ -1,4 +1,5 @@
 // frontend/src/lib/utils/apiUtils.ts
+import { loadingStore } from './loadingStore';
 
 // Function to get a cookie by name
 function getCookie(name: string): string | null {
@@ -40,5 +41,10 @@ export async function apiFetch(url: string, options: FetchOptions = {}): Promise
 
   options.headers = headers;
 
-  return fetch(url, options);
+  loadingStore.start();
+  try {
+    return await fetch(url, options);
+  } finally {
+    loadingStore.end();
+  }
 }

--- a/frontend/src/lib/utils/loadingStore.ts
+++ b/frontend/src/lib/utils/loadingStore.ts
@@ -1,0 +1,13 @@
+import { writable } from 'svelte/store';
+
+function createLoadingStore() {
+  const { subscribe, set, update } = writable(0);
+  return {
+    subscribe,
+    start: () => update(n => n + 1),
+    end: () => update(n => Math.max(0, n - 1)),
+    reset: () => set(0)
+  };
+}
+
+export const loadingStore = createLoadingStore();

--- a/frontend/src/routes/+layout.svelte
+++ b/frontend/src/routes/+layout.svelte
@@ -111,9 +111,14 @@
   }
 
   // Global loading indicator state
-  let globalLoading = false;
-  const unsubscribeNavigating = navigating.subscribe(value => {
-    globalLoading = !!value; // true if navigating, false otherwise
+  import { loadingStore } from '$lib/utils/loadingStore';
+
+  const unsubscribeNavigating = navigating.subscribe((value) => {
+    if (value) {
+      loadingStore.start();
+    } else {
+      loadingStore.end();
+    }
   });
 
   onDestroy(() => {
@@ -157,7 +162,7 @@
 
 </script>
 
-<GlobalLoadingIndicator loading={globalLoading} />
+<GlobalLoadingIndicator />
 
 <main class="min-h-screen flex bg-base text-gray-900 dark:bg-neutral-900 dark:text-gray-100">
   {#if loggedIn && org}


### PR DESCRIPTION
## Summary
- introduce a `loadingStore` to track active API requests
- display GlobalLoadingIndicator based on store state
- increment/decrement the store in `apiFetch`
- hook SvelteKit navigation events into loading store
- update GlobalLoadingIndicator tests for store behaviour

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_68691192e3188333931ae9cfc7eab29d