### PR TITLE
Update TLS and image version docs

### DIFF
--- a/docs/Deployment.md
+++ b/docs/Deployment.md
@@ -38,3 +38,55 @@ Set the `REGISTRY` secret in your CI settings so images are pushed to your conta
 ## TLS / HTTPS
 
 The backend itself does not terminate TLS. In production deploy it behind a reverse proxy or Kubernetes ingress that provides HTTPS. Configure `BASE_URL` and `FRONTEND_ORIGIN` with `https://` URLs so that login cookies receive the `Secure` flag and browsers enforce encrypted connections. Any ingress controller such as Nginx or Traefik can handle the certificates and forward traffic to the pod on port `8080`.
+
+Example Nginx ingress:
+
+```yaml
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: backend-ingress
+  annotations:
+    nginx.ingress.kubernetes.io/force-ssl-redirect: "true"
+spec:
+  tls:
+  - hosts:
+    - example.com
+    secretName: tls-secret
+  rules:
+  - host: example.com
+    http:
+      paths:
+      - path: /
+        pathType: Prefix
+        backend:
+          service:
+            name: backend
+            port:
+              number: 80
+```
+
+The same concept applies for Traefik using `IngressRoute` objects to route
+HTTPS traffic to the backend service.
+
+## Versioned images with Helm
+
+An example `values.yaml` could look like:
+
+```yaml
+backendImage:
+  repository: myorg/backend
+  tag: v1.0.0
+frontendImage:
+  repository: myorg/frontend
+  tag: v1.0.0
+```
+
+These values are referenced in the deployment manifest as:
+
+```yaml
+image: "{{ .Values.backendImage.repository }}:{{ .Values.backendImage.tag }}"
+```
+
+Kustomize users can achieve the same by applying an `image` patch that sets the
+tag for each deployment.

--- a/k8s/backend-deployment.yaml
+++ b/k8s/backend-deployment.yaml
@@ -14,7 +14,7 @@ spec:
     spec:
       containers:
       - name: backend
-        image: myorg/backend:latest
+        image: "{{ .Values.backendImage.repository }}:{{ .Values.backendImage.tag | default \"latest\" }}"
         envFrom:
         - secretRef:
             name: backend-env

--- a/k8s/cleanup-cronjob.yaml
+++ b/k8s/cleanup-cronjob.yaml
@@ -10,7 +10,7 @@ spec:
         spec:
           containers:
           - name: cleanup
-            image: myorg/backend:latest
+            image: "{{ .Values.backendImage.repository }}:{{ .Values.backendImage.tag | default \"latest\" }}"
             command: ["/usr/local/bin/cleanup"]
             envFrom:
             - secretRef:

--- a/k8s/frontend-deployment.yaml
+++ b/k8s/frontend-deployment.yaml
@@ -14,7 +14,7 @@ spec:
     spec:
       containers:
       - name: frontend
-        image: myorg/frontend:latest
+        image: "{{ .Values.frontendImage.repository }}:{{ .Values.frontendImage.tag | default \"latest\" }}"
         envFrom:
         - secretRef:
             name: frontend-env


### PR DESCRIPTION
## Summary
- expand deployment guide with a TLS ingress example
- document image versioning with Helm values
- allow image tags to be templated in k8s manifests

## Testing
- `cargo test --manifest-path backend/Cargo.toml` *(fails: build dependencies missing or timeout)*
- `npm test --prefix frontend` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6869119124348333887487020772e551