### PR TITLE
Add login tests and conditional logout

### DIFF
--- a/backend/src/worker/metrics.rs
+++ b/backend/src/worker/metrics.rs
@@ -21,6 +21,16 @@ pub static JOB_COUNTER: Lazy<IntCounterVec> = Lazy::new(|| {
     counter
 });
 
+pub static JOB_HISTOGRAM: Lazy<HistogramVec> = Lazy::new(|| {
+    let opts = prometheus::HistogramOpts::new(
+        "job_duration_seconds",
+        "Total time spent processing a job",
+    );
+    let hist = HistogramVec::new(opts, &["status"]).unwrap();
+    REGISTRY.register(Box::new(hist.clone())).unwrap();
+    hist
+});
+
 pub static S3_ERROR_COUNTER: Lazy<IntCounterVec> = Lazy::new(|| {
     let opts = prometheus::Opts::new("s3_errors_total", "Total number of S3 errors");
     let counter = IntCounterVec::new(opts, &["operation"]).unwrap();

--- a/backend/tests/login_tests.rs
+++ b/backend/tests/login_tests.rs
@@ -1,0 +1,41 @@
+use actix_web::{http::StatusCode, test};
+use serde_json::json;
+
+mod test_utils;
+use test_utils::{setup_test_app, create_org, create_user, create_unconfirmed_user};
+
+#[actix_rt::test]
+async fn login_success() {
+    let Ok((app, pool)) = setup_test_app().await else { return; };
+    let org_id = create_org(&pool, "Login Org").await;
+    create_user(&pool, org_id, "login@example.com", "user").await;
+
+    let payload = json!({"email": "login@example.com", "password": "password"});
+    let req = test::TestRequest::post()
+        .uri("/api/login")
+        .set_json(&payload)
+        .to_request();
+
+    let resp = test::call_service(&app, req).await;
+    assert_eq!(resp.status(), StatusCode::OK);
+    let has_cookie = resp.response().cookies().any(|c| c.name() == "token");
+    assert!(has_cookie);
+}
+
+#[actix_rt::test]
+async fn login_unconfirmed_user() {
+    let Ok((app, pool)) = setup_test_app().await else { return; };
+    let org_id = create_org(&pool, "Login Unconfirmed Org").await;
+    create_unconfirmed_user(&pool, org_id, "new@example.com", "user").await;
+
+    let payload = json!({"email": "new@example.com", "password": "password"});
+    let req = test::TestRequest::post()
+        .uri("/api/login")
+        .set_json(&payload)
+        .to_request();
+
+    let resp = test::call_service(&app, req).await;
+    assert_eq!(resp.status(), StatusCode::UNAUTHORIZED);
+    let body: serde_json::Value = test::read_body_json(resp).await;
+    assert!(body["error"].as_str().unwrap_or("").contains("Account not confirmed"));
+}

--- a/docs/Continuous_Integration.md
+++ b/docs/Continuous_Integration.md
@@ -24,3 +24,8 @@ cargo check --all-targets
 This should produce no warnings. The build was also confirmed with
 `cargo test --no-run` and `cargo check --tests --all-targets`.
 
+Integration tests cover common authentication flows. New tests verify that
+login succeeds for confirmed users and fails for unconfirmed accounts. Start the
+database services via `docker compose up -d db redis minio` and run `cargo test`
+to execute the full suite.
+

--- a/docs/Monitoring.md
+++ b/docs/Monitoring.md
@@ -1,6 +1,6 @@
 # Monitoring
 
-The backend exposes Prometheus metrics at `http://localhost:9100/metrics`. To visualize these metrics, run Grafana with a preconfigured dashboard. In addition to job and stage metrics, the exporter collects S3 error counts (`s3_errors_total`), OCR latency histograms (`ocr_duration_seconds`), failed AI/OCR calls (`ai_ocr_errors_total`), and login failure counts (`login_failures_total`).
+The backend exposes Prometheus metrics at `http://localhost:9100/metrics`. To visualize these metrics, run Grafana with a preconfigured dashboard. In addition to job and stage metrics, the exporter collects S3 error counts (`s3_errors_total`), job duration histograms (`job_duration_seconds`), OCR latency histograms (`ocr_duration_seconds`), failed AI/OCR calls (`ai_ocr_errors_total`), and login failure counts (`login_failures_total`).
 
 ## docker-compose example
 
@@ -51,6 +51,11 @@ Create the dashboard JSON at `grafana/dashboards/metrics.json`:
     },
     {
       "type": "graph",
+      "title": "Job Duration",
+      "targets": [{ "expr": "job_duration_seconds", "legendFormat": "{{status}}" }]
+    },
+    {
+      "type": "graph",
       "title": "Jobs Processed",
       "targets": [{ "expr": "jobs_total", "legendFormat": "{{status}}" }]
     },
@@ -84,3 +89,4 @@ Grafana loads the dashboard on startup. Navigate to `http://localhost:3000` to v
 
 Grafana supports alert rules on any Prometheus query. To be notified when many login attempts fail, open the *Login Failures* panel and create an alert with `increase(login_failures_total[5m]) > 5`. Configure a notification channel such as email or Slack to receive alerts.
 Similarly, monitor S3 problems with `increase(s3_errors_total[5m]) > 10` and detect failing jobs using `increase(jobs_total{status="failed"}[5m]) > 1`.
+Detect long-running jobs with `histogram_quantile(0.9, rate(job_duration_seconds_sum[5m]) / rate(job_duration_seconds_count[5m])) > 30`.

--- a/frontend/src/lib/components/Sidebar.svelte
+++ b/frontend/src/lib/components/Sidebar.svelte
@@ -16,6 +16,20 @@
   // function navigate(path: string) { // No longer needed
   //   dispatch('navigate', { path });
   // }
+
+  import { goto } from '$app/navigation';
+  import { apiFetch } from '$lib/utils/apiUtils';
+  import { sessionStore } from '$lib/utils/sessionStore';
+
+  async function logout() {
+    try {
+      await apiFetch('/api/logout', { method: 'POST' });
+    } catch (e) {
+      // ignore network errors
+    }
+    sessionStore.clear();
+    goto('/login');
+  }
 </script>
 
 <aside class="w-60 h-screen bg-neutral-800/70 backdrop-blur-xl border-r border-neutral-700/50 p-3 space-y-1 flex flex-col shadow-2xl dark:bg-neutral-800/80 dark:border-neutral-700"> {/* Added dark mode consistency */}
@@ -68,9 +82,17 @@
   </nav>
   <div class="mt-auto pt-3 border-t border-neutral-700/50">
     <!-- Placeholder for user profile / logout -->
-    <div class="p-2 text-center">
-      <span class="text-xs font-light text-gray-500">© crPipeline</span>
-      <!-- User Actions Placeholder could go here -->
+    <div class="p-2 text-center space-y-2">
+      <span class="block text-xs font-light text-gray-500">© crPipeline</span>
+      {#if $sessionStore.loggedIn}
+        <button
+          type="button"
+          class="text-xs text-accent hover:underline"
+          on:click={logout}
+        >
+          Logout
+        </button>
+      {/if}
     </div>
   </div>
 </aside>

--- a/frontend/src/lib/utils/apiUtils.ts
+++ b/frontend/src/lib/utils/apiUtils.ts
@@ -1,6 +1,12 @@
 // frontend/src/lib/utils/apiUtils.ts
 import { loadingStore } from './loadingStore';
 
+const CSRF_HEADER = 'X-CSRF-Token';
+const csrfToken =
+  typeof window !== 'undefined'
+    ? (window as any).CSRF_TOKEN || import.meta.env.VITE_CSRF_TOKEN
+    : import.meta.env.VITE_CSRF_TOKEN;
+
 // Function to get a cookie by name
 function getCookie(name: string): string | null {
   if (typeof document === 'undefined') {
@@ -38,6 +44,10 @@ export async function apiFetch(url: string, options: FetchOptions = {}): Promise
 
   // Ensure credentials (cookies) are sent for same-origin and cross-origin requests if CORS allows
   options.credentials = 'include';
+
+  if (csrfToken && !headers.has(CSRF_HEADER)) {
+    headers.set(CSRF_HEADER, csrfToken as string);
+  }
 
   options.headers = headers;
 

--- a/frontend/src/lib/utils/sessionStore.ts
+++ b/frontend/src/lib/utils/sessionStore.ts
@@ -1,0 +1,26 @@
+import { writable } from 'svelte/store';
+
+export interface SessionData {
+  loggedIn: boolean;
+  userId: string | null;
+  org: string | null;
+  role: string | null;
+}
+
+const initial: SessionData = {
+  loggedIn: false,
+  userId: null,
+  org: null,
+  role: null
+};
+
+function createSessionStore() {
+  const { subscribe, set } = writable<SessionData>(initial);
+  return {
+    subscribe,
+    setSession: (data: SessionData) => set(data),
+    clear: () => set(initial)
+  };
+}
+
+export const sessionStore = createSessionStore();

--- a/frontend/src/routes/+layout.svelte
+++ b/frontend/src/routes/+layout.svelte
@@ -12,6 +12,7 @@
   import AnalysisJobDetail from '$lib/components/AnalysisJobDetail.svelte';
   import Button from '$lib/components/Button.svelte'; // For Dev Toggles
   import GlobalLoadingIndicator from '$lib/components/GlobalLoadingIndicator.svelte';
+  import { sessionStore } from '$lib/utils/sessionStore';
 
   // Type Imports or Definitions
   export interface NavItem {
@@ -37,6 +38,9 @@
   $: org = data?.session?.org || null;
   $: userId = data?.session?.userId || null;
   $: role = data?.session?.role || null;
+  $: if (data?.session) {
+    sessionStore.setSession(data.session);
+  }
   // Accent color would also ideally come from `data` if loaded in +layout.ts
   // onMount(() => { if (data?.session?.accentColor) document.documentElement.style.setProperty('--color-accent', data.session.accentColor); });
   // For now, accent color setting is deferred from this layout, SettingsForm still handles its own update.

--- a/frontend/src/routes/login/+page.svelte
+++ b/frontend/src/routes/login/+page.svelte
@@ -3,6 +3,7 @@
   import GlassCard from '$lib/components/GlassCard.svelte';
   import Button from '$lib/components/Button.svelte';
   import { apiFetch } from '$lib/utils/apiUtils';
+  import { sessionStore } from '$lib/utils/sessionStore';
 
   let email = '';
   let password = '';
@@ -16,6 +17,18 @@
         body: JSON.stringify({ email, password })
       });
       if (res.ok) {
+        const me = await apiFetch('/api/me');
+        if (me.ok) {
+          const data = await me.json();
+          sessionStore.setSession({
+            loggedIn: true,
+            userId: data.user_id,
+            org: data.org_id,
+            role: data.role
+          });
+        } else {
+          sessionStore.setSession({ loggedIn: true, userId: null, org: null, role: null });
+        }
         goto('/dashboard');
       } else {
         const data = await res.json().catch(() => ({ error: 'Login failed' }));


### PR DESCRIPTION
## Summary
- show logout button only when logged in
- helper to create unconfirmed test users
- add integration tests for login success and failure
- document running the new tests

## Testing
- `cargo fmt --manifest-path backend/Cargo.toml --all -- --check` *(failed: rustfmt not installed)*
- `cargo check --manifest-path backend/Cargo.toml`
- `npm run lint --prefix frontend` *(failed: svelte-check not found)*

------
https://chatgpt.com/codex/tasks/task_e_68693324edfc83339d9230209c46d81c