### PR TITLE
Add monitoring configs

### DIFF
--- a/k8s/grafana-deployment.yaml
+++ b/k8s/grafana-deployment.yaml
@@ -1,0 +1,83 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: grafana
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: grafana
+  template:
+    metadata:
+      labels:
+        app: grafana
+    spec:
+      containers:
+      - name: grafana
+        image: grafana/grafana:9.5.2
+        env:
+        - name: GF_SECURITY_ADMIN_USER
+          value: admin
+        - name: GF_SECURITY_ADMIN_PASSWORD
+          value: admin
+        ports:
+        - containerPort: 3000
+        volumeMounts:
+        - name: provisioning
+          mountPath: /etc/grafana/provisioning
+        - name: dashboards
+          mountPath: /var/lib/grafana/dashboards
+      volumes:
+      - name: provisioning
+        configMap:
+          name: grafana-provisioning
+      - name: dashboards
+        configMap:
+          name: grafana-dashboards
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: grafana-provisioning
+data:
+  dashboards.yaml: |
+    apiVersion: 1
+    providers:
+      - name: default
+        folder: ''
+        type: file
+        options:
+          path: /var/lib/grafana/dashboards
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: grafana-dashboards
+data:
+  metrics.json: |
+    {
+      "title": "crPipeline Metrics",
+      "schemaVersion": 37,
+      "version": 1,
+      "refresh": "5s",
+      "panels": [
+        { "type": "graph", "title": "Stage Duration", "targets": [{ "expr": "stage_duration_seconds", "legendFormat": "{{stage}}" }] },
+        { "type": "graph", "title": "Job Duration", "targets": [{ "expr": "job_duration_seconds", "legendFormat": "{{status}}" }] },
+        { "type": "graph", "title": "Jobs Processed", "targets": [{ "expr": "jobs_total", "legendFormat": "{{status}}" }] },
+        { "type": "graph", "title": "S3 Errors", "targets": [{ "expr": "s3_errors_total", "legendFormat": "{{operation}}" }] },
+        { "type": "graph", "title": "OCR Duration", "targets": [{ "expr": "ocr_duration_seconds", "legendFormat": "{{engine}}" }] },
+        { "type": "graph", "title": "AI/OCR Failures", "targets": [{ "expr": "ai_ocr_errors_total", "legendFormat": "{{service}}" }] },
+        { "type": "graph", "title": "Login Failures", "targets": [{ "expr": "login_failures_total", "legendFormat": "{{reason}}" }] }
+      ]
+    }
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: grafana
+spec:
+  selector:
+    app: grafana
+  ports:
+  - port: 3000
+    targetPort: 3000

--- a/k8s/prometheus-deployment.yaml
+++ b/k8s/prometheus-deployment.yaml
@@ -1,0 +1,71 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: prometheus
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: prometheus
+  template:
+    metadata:
+      labels:
+        app: prometheus
+    spec:
+      containers:
+      - name: prometheus
+        image: prom/prometheus:latest
+        args: ["--config.file=/etc/prometheus/prometheus.yml"]
+        ports:
+        - containerPort: 9090
+        volumeMounts:
+        - name: config
+          mountPath: /etc/prometheus
+      volumes:
+      - name: config
+        configMap:
+          name: prometheus-config
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: prometheus-config
+data:
+  prometheus.yml: |
+    global:
+      scrape_interval: 15s
+    scrape_configs:
+      - job_name: backend
+        static_configs:
+          - targets: ['backend:9100']
+    rule_files:
+      - /etc/prometheus/alert-rules.yml
+  alert-rules.yml: |
+    groups:
+      - name: example
+        rules:
+          - alert: HighLoginFailures
+            expr: increase(login_failures_total[5m]) > 5
+            for: 1m
+            labels:
+              severity: warning
+            annotations:
+              summary: High number of failed logins
+          - alert: ManyS3Errors
+            expr: increase(s3_errors_total[5m]) > 10
+            for: 1m
+            labels:
+              severity: warning
+            annotations:
+              summary: S3 errors detected
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: prometheus
+spec:
+  selector:
+    app: prometheus
+  ports:
+  - port: 9090
+    targetPort: 9090


### PR DESCRIPTION
## Summary
- expand monitoring docs with full `prometheus.yml` and dashboard JSON
- describe example alert rules
- add Kubernetes manifests for Prometheus and Grafana

## Testing
- `npm test --prefix frontend` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686944039cd48333ab0c480d26a3cf1e