### PR TITLE
Add Kubernetes secret generation and ingress docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,15 @@ Multi-tenant document analysis platform built with Rust and Svelte.
 
 See [PLAN.md](PLAN.md) for the project roadmap.
 
+## CI/CD secret generation
+
+Automated pipelines can run `scripts/generate_secrets.sh` to create the `.env` file used by the backend. Pass `--k8s` to also emit a Kubernetes Secret manifest which can be applied directly:
+
+```bash
+scripts/generate_secrets.sh backend/.env.prod --k8s > k8s/backend-secret.yaml
+kubectl apply -f k8s/backend-secret.yaml
+```
+
 ## License
 
 This project is licensed under the [MIT License](LICENSE).

--- a/scripts/generate_secrets.sh
+++ b/scripts/generate_secrets.sh
@@ -1,8 +1,26 @@
 #!/bin/bash
 set -e
 
-# Generate a .env file with random secrets suitable for production
-OUTPUT=${1:-backend/.env.prod}
+# Generate a .env file with random secrets suitable for production.
+# Usage: ./generate_secrets.sh [OUTPUT] [--k8s]
+# When --k8s is supplied the script also prints a Kubernetes Secret manifest
+# to stdout. Redirect the output to a file or pipe it directly to kubectl.
+
+OUTPUT="backend/.env.prod"
+K8S=0
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --k8s)
+      K8S=1
+      shift
+      ;;
+    *)
+      OUTPUT="$1"
+      shift
+      ;;
+  esac
+done
 
 JWT_SECRET=$(openssl rand -hex 32)
 AWS_ACCESS_KEY=${AWS_ACCESS_KEY:-$(openssl rand -hex 12)}
@@ -23,3 +41,24 @@ AI_API_KEY=
 EOT
 
 echo "Generated $OUTPUT with random credentials. Fill DATABASE_URL and other settings as needed."
+
+if [[ $K8S -eq 1 ]]; then
+cat <<EOF
+apiVersion: v1
+kind: Secret
+metadata:
+  name: backend-env
+type: Opaque
+data:
+  DATABASE_URL: $(printf "" | base64 -w0)
+  JWT_SECRET: $(printf "%s" "$JWT_SECRET" | base64 -w0)
+  AWS_ENDPOINT: $(printf "" | base64 -w0)
+  AWS_ACCESS_KEY: $(printf "%s" "$AWS_ACCESS_KEY" | base64 -w0)
+  AWS_SECRET_KEY: $(printf "%s" "$AWS_SECRET_KEY" | base64 -w0)
+  S3_BUCKET: $(printf "uploads" | base64 -w0)
+  FRONTEND_ORIGIN: $(printf "" | base64 -w0)
+  REDIS_URL: $(printf "%s" "$REDIS_URL" | base64 -w0)
+  AI_API_URL: $(printf "" | base64 -w0)
+  AI_API_KEY: $(printf "" | base64 -w0)
+EOF
+fi


### PR DESCRIPTION
## Summary
- document new TLS/Ingress setup in deployment guide
- add optional `--k8s` support to `generate_secrets.sh`
- document using `generate_secrets.sh` in CI/CD workflow

## Testing
- `cargo test --manifest-path backend/Cargo.toml --no-run`
- `npm test --prefix frontend -- --run`


------
https://chatgpt.com/codex/tasks/task_e_6869440333188333b01b069d475c3d91