### PR TITLE
Add document download endpoint

### DIFF
--- a/backend/src/handlers/document.rs
+++ b/backend/src/handlers/document.rs
@@ -1,17 +1,21 @@
-use actix_multipart::Multipart;
-use actix_web::{post, web, HttpResponse};
-use futures_util::StreamExt as _;
-use aws_sdk_s3::Client;
-use uuid::Uuid;
-use lopdf::Document as PdfDoc;
-use crate::models::{Document, NewDocument, AnalysisJob, NewAnalysisJob, OrgSettings, DocumentError};
-use crate::utils::log_action;
 use crate::middleware::auth::AuthUser;
-use sqlx::PgPool;
-use sanitize_filename; // Added for sanitizing filenames
+use crate::models::{
+    AnalysisJob, Document, DocumentError, NewAnalysisJob, NewDocument, OrgSettings,
+};
+use crate::utils::log_action;
+use actix_multipart::Multipart;
+use actix_web::{get, post, web, HttpResponse};
 use anyhow::Error;
 use async_trait::async_trait;
+use aws_sdk_s3::{presigning::PresigningConfig, Client};
+use futures_util::StreamExt as _;
+use lopdf::Document as PdfDoc;
 use redis::AsyncCommands;
+use sanitize_filename; // Added for sanitizing filenames
+use sqlx::PgPool;
+use std::path::Path;
+use std::time::Duration;
+use uuid::Uuid;
 
 /// Abstraction over S3 deletion used for easier testing.
 #[async_trait]
@@ -34,7 +38,12 @@ impl S3Deleter for Client {
 
 pub async fn cleanup_s3_object<S: S3Deleter + Sync>(s3: &S, bucket: &str, key: &str) {
     if let Err(e) = s3.delete_object(bucket, key).await {
-        log::error!("Failed to delete {} from S3 bucket {} during cleanup: {:?}", key, bucket, e);
+        log::error!(
+            "Failed to delete {} from S3 bucket {} during cleanup: {:?}",
+            key,
+            bucket,
+            e
+        );
     }
 }
 
@@ -63,8 +72,14 @@ async fn check_upload_quota(pool: &PgPool, org_id: Uuid) -> Result<(), HttpRespo
             Ok(())
         }
         Err(e) => {
-            log::error!("Could not verify organization settings for quota (org_id {}): {:?}", org_id, e);
-            Err(HttpResponse::InternalServerError().json(serde_json::json!({"error": "Could not verify organization settings for quota."})))
+            log::error!(
+                "Could not verify organization settings for quota (org_id {}): {:?}",
+                org_id,
+                e
+            );
+            Err(HttpResponse::InternalServerError().json(
+                serde_json::json!({"error": "Could not verify organization settings for quota."}),
+            ))
         }
     }
 }
@@ -85,7 +100,11 @@ async fn check_analysis_quota(pool: &PgPool, org_id: Uuid) -> Result<(), HttpRes
             Ok(())
         }
         Err(e) => {
-            log::error!("Could not verify organization settings for analysis quota (org_id {}): {:?}", org_id, e);
+            log::error!(
+                "Could not verify organization settings for analysis quota (org_id {}): {:?}",
+                org_id,
+                e
+            );
             Err(HttpResponse::InternalServerError().json(serde_json::json!({"error": "Could not verify organization settings for analysis quota."})))
         }
     }
@@ -162,7 +181,9 @@ async fn validate_document(
         }
         if !bytes_data.starts_with(PDF_MAGIC_BYTES) {
             log::warn!("Invalid PDF magic bytes for file '{}'", user_filename);
-            return Err(HttpResponse::BadRequest().json(serde_json::json!({"error": "Invalid PDF file format (magic bytes mismatch)."})));
+            return Err(HttpResponse::BadRequest().json(
+                serde_json::json!({"error": "Invalid PDF file format (magic bytes mismatch)."}),
+            ));
         }
         "pdf"
     } else if lower_filename.ends_with(".md") {
@@ -243,14 +264,11 @@ pub async fn upload(
     }
 
     // Validate file and get PDF page count
-    let (base_filename, pages) = match validate_document(
-        &user_provided_filename,
-        &file_content_type,
-        &bytes_data,
-    ).await {
-        Ok(v) => v,
-        Err(resp) => return resp,
-    };
+    let (base_filename, pages) =
+        match validate_document(&user_provided_filename, &file_content_type, &bytes_data).await {
+            Ok(v) => v,
+            Err(resp) => return resp,
+        };
 
     // Authz check
     if params.org_id != user.org_id && user.role != "admin" {
@@ -260,8 +278,9 @@ pub async fn upload(
             user.org_id,
             params.org_id
         );
-        return HttpResponse::Unauthorized()
-            .json(serde_json::json!({"error": "You are not authorized to upload to this organization."}));
+        return HttpResponse::Unauthorized().json(
+            serde_json::json!({"error": "You are not authorized to upload to this organization."}),
+        );
     }
 
     // Quota check (target docs)
@@ -292,19 +311,33 @@ pub async fn upload(
     let created_document = match Document::create(&pool, doc_to_create).await {
         Ok(d) => d,
         Err(DocumentError::SanitizationFailed) => {
-            log::warn!("Rejected unsafe filename during document creation: {}", s3_key_name);
+            log::warn!(
+                "Rejected unsafe filename during document creation: {}",
+                s3_key_name
+            );
             cleanup_s3_object(s3.get_ref(), &bucket, &s3_key_name).await;
-            return HttpResponse::BadRequest().json(serde_json::json!({"error": "Invalid filename."}));
+            return HttpResponse::BadRequest()
+                .json(serde_json::json!({"error": "Invalid filename."}));
         }
         Err(DocumentError::Sqlx(e)) => {
-            log::error!("Failed to create document record for S3 key {}: {:?}", s3_key_name, e);
+            log::error!(
+                "Failed to create document record for S3 key {}: {:?}",
+                s3_key_name,
+                e
+            );
             cleanup_s3_object(s3.get_ref(), &bucket, &s3_key_name).await;
             return HttpResponse::InternalServerError()
                 .json(serde_json::json!({"error": "Failed to save document information."}));
         }
     };
 
-    log_action(&pool, user.org_id, user.user_id, &format!("upload:{}", created_document.id)).await;
+    log_action(
+        &pool,
+        user.org_id,
+        user.user_id,
+        &format!("upload:{}", created_document.id),
+    )
+    .await;
 
     // Optional: Queue for analysis
     if let Some(pipeline_id) = params.pipeline_id {
@@ -320,7 +353,13 @@ pub async fn upload(
         };
         match AnalysisJob::create(&pool, job_to_create).await {
             Ok(j) => {
-                log_action(&pool, user.org_id, user.user_id, &format!("job_created:{}", j.id)).await;
+                log_action(
+                    &pool,
+                    user.org_id,
+                    user.user_id,
+                    &format!("job_created:{}", j.id),
+                )
+                .await;
                 if let Ok(redis_url) = std::env::var("REDIS_URL") {
                     if let Ok(client) = redis::Client::open(redis_url) {
                         if let Ok(mut conn) = client.get_async_connection().await {
@@ -336,7 +375,11 @@ pub async fn upload(
                 }
             }
             Err(e) => {
-                log::error!("Failed to create analysis job for document {}: {:?}", created_document.id, e);
+                log::error!(
+                    "Failed to create analysis job for document {}: {:?}",
+                    created_document.id,
+                    e
+                );
                 cleanup_s3_object(s3.get_ref(), &bucket, &s3_key_name).await;
                 return HttpResponse::InternalServerError()
                     .json(serde_json::json!({"error": "Failed to queue analysis job."}));
@@ -347,7 +390,89 @@ pub async fn upload(
     HttpResponse::Ok().json(created_document)
 }
 
+/// Download a document either by streaming locally when `LOCAL_S3_DIR` is set
+/// or by returning a presigned S3 URL.
+#[get("/download/{document_id}")]
+pub async fn download(
+    path: web::Path<Uuid>,
+    user: AuthUser,
+    pool: web::Data<PgPool>,
+    s3: web::Data<Client>,
+) -> HttpResponse {
+    let document_id = path.into_inner();
+
+    let doc = match sqlx::query_as::<_, Document>("SELECT * FROM documents WHERE id=$1")
+        .bind(document_id)
+        .fetch_optional(pool.as_ref())
+        .await
+    {
+        Ok(Some(d)) => d,
+        Ok(None) => return HttpResponse::NotFound().finish(),
+        Err(e) => {
+            log::error!("Failed to fetch document {}: {:?}", document_id, e);
+            return HttpResponse::InternalServerError().finish();
+        }
+    };
+
+    if doc.org_id != user.org_id && user.role != "admin" {
+        log::warn!(
+            "Unauthorized download attempt {} by user {} (org {})",
+            document_id,
+            user.user_id,
+            user.org_id
+        );
+        return HttpResponse::Unauthorized().finish();
+    }
+
+    if let Ok(local_dir) = std::env::var("LOCAL_S3_DIR") {
+        let path = Path::new(&local_dir).join(&doc.filename);
+        match tokio::fs::read(path).await {
+            Ok(bytes) => HttpResponse::Ok()
+                .append_header(("Content-Type", "application/pdf"))
+                .append_header((
+                    "Content-Disposition",
+                    format!("attachment; filename=\"{}\"", doc.display_name),
+                ))
+                .body(bytes),
+            Err(e) => {
+                log::error!(
+                    "Failed to read local file for document {}: {:?}",
+                    document_id,
+                    e
+                );
+                HttpResponse::InternalServerError().finish()
+            }
+        }
+    } else {
+        let bucket = std::env::var("S3_BUCKET").unwrap_or_else(|_| "uploads".into());
+        let presign_cfg = match PresigningConfig::expires_in(Duration::from_secs(3600)) {
+            Ok(cfg) => cfg,
+            Err(e) => {
+                log::error!(
+                    "Failed to create presign config for {}: {:?}",
+                    document_id,
+                    e
+                );
+                return HttpResponse::InternalServerError().finish();
+            }
+        };
+        match s3
+            .get_object()
+            .bucket(&bucket)
+            .key(&doc.filename)
+            .presigned(presign_cfg)
+            .await
+        {
+            Ok(req) => HttpResponse::Ok().json(serde_json::json!({"url": req.uri().to_string()})),
+            Err(e) => {
+                log::error!("Failed to presign document {}: {:?}", document_id, e);
+                HttpResponse::InternalServerError().finish()
+            }
+        }
+    }
+}
+
 /// Configure Actix routes for document-related endpoints.
 pub fn routes(cfg: &mut web::ServiceConfig) {
-    cfg.service(upload);
+    cfg.service(upload).service(download);
 }

--- a/backend/tests/document_tests.rs
+++ b/backend/tests/document_tests.rs
@@ -1,19 +1,28 @@
-use actix_web::{test, web, App, http::header};
+use actix_web::{http::header, test, web, App};
 use backend::handlers;
-use sqlx::{PgPool, postgres::PgPoolOptions};
+use sqlx::{postgres::PgPoolOptions, PgPool};
 
 mod test_utils;
-use test_utils::{create_org, create_user, generate_jwt_token};
-use wiremock::{MockServer, Mock, ResponseTemplate};
-use wiremock::matchers::method;
 use aws_config::meta::region::RegionProviderChain;
 use aws_sdk_s3::Client as S3Client;
-use backend::models::{NewDocument, Document, NewPipeline, Pipeline};
+use backend::models::{Document, NewDocument, NewPipeline, Pipeline};
+use mini_redis::server;
+use test_utils::{create_org, create_user, generate_jwt_token};
 use tokio::net::TcpListener;
 use tokio::sync::oneshot;
-use mini_redis::server;
+use wiremock::matchers::method;
+use wiremock::{Mock, MockServer, ResponseTemplate};
 
-async fn setup_test_app(s3_server: &MockServer) -> (impl actix_web::dev::Service<actix_http::Request, Response=actix_web::dev::ServiceResponse, Error=actix_web::Error>, PgPool) {
+async fn setup_test_app(
+    s3_server: &MockServer,
+) -> (
+    impl actix_web::dev::Service<
+        actix_http::Request,
+        Response = actix_web::dev::ServiceResponse,
+        Error = actix_web::Error,
+    >,
+    PgPool,
+) {
     dotenvy::dotenv().ok();
     let database_url = std::env::var("DATABASE_URL_TEST")
         .unwrap_or_else(|_| std::env::var("DATABASE_URL").expect("DATABASE_URL must be set"));
@@ -41,8 +50,9 @@ async fn setup_test_app(s3_server: &MockServer) -> (impl actix_web::dev::Service
         App::new()
             .app_data(web::Data::new(pool.clone()))
             .app_data(web::Data::new(s3_client.clone()))
-            .configure(handlers::init)
-    ).await;
+            .configure(handlers::init),
+    )
+    .await;
     (app, pool)
 }
 
@@ -50,10 +60,14 @@ async fn start_redis() -> (oneshot::Sender<()>, u16) {
     let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
     let port = listener.local_addr().unwrap().port();
     let (tx, rx) = oneshot::channel();
-    tokio::spawn(async move { let _ = server::run(listener, async { let _ = rx.await; }).await; });
+    tokio::spawn(async move {
+        let _ = server::run(listener, async {
+            let _ = rx.await;
+        })
+        .await;
+    });
     (tx, port)
 }
-
 
 fn multipart_body(boundary: &str, filename: &str, content_type: &str, content: &str) -> String {
     format!(
@@ -84,7 +98,10 @@ async fn test_pdf_upload_success() {
     let req = test::TestRequest::post()
         .uri(&format!("/api/upload?org_id={}&is_target=true", org_id))
         .insert_header((header::AUTHORIZATION, format!("Bearer {}", token)))
-        .insert_header((header::CONTENT_TYPE, format!("multipart/form-data; boundary={}", boundary)))
+        .insert_header((
+            header::CONTENT_TYPE,
+            format!("multipart/form-data; boundary={}", boundary),
+        ))
         .set_payload(body)
         .to_request();
     let resp = test::call_service(&app, req).await;
@@ -117,7 +134,10 @@ async fn test_pdf_upload_bad_content_type() {
     let req = test::TestRequest::post()
         .uri(&format!("/api/upload?org_id={}&is_target=true", org_id))
         .insert_header((header::AUTHORIZATION, format!("Bearer {}", token)))
-        .insert_header((header::CONTENT_TYPE, format!("multipart/form-data; boundary={}", boundary)))
+        .insert_header((
+            header::CONTENT_TYPE,
+            format!("multipart/form-data; boundary={}", boundary),
+        ))
         .set_payload(body)
         .to_request();
     let resp = test::call_service(&app, req).await;
@@ -163,11 +183,17 @@ async fn test_cleanup_on_failed_upload() {
     let req = test::TestRequest::post()
         .uri(&format!("/api/upload?org_id={}&is_target=true", org_id))
         .insert_header((header::AUTHORIZATION, format!("Bearer {}", token)))
-        .insert_header((header::CONTENT_TYPE, format!("multipart/form-data; boundary={}", boundary)))
+        .insert_header((
+            header::CONTENT_TYPE,
+            format!("multipart/form-data; boundary={}", boundary),
+        ))
         .set_payload(body)
         .to_request();
     let resp = test::call_service(&app, req).await;
-    assert_eq!(resp.status(), actix_web::http::StatusCode::INTERNAL_SERVER_ERROR);
+    assert_eq!(
+        resp.status(),
+        actix_web::http::StatusCode::INTERNAL_SERVER_ERROR
+    );
     let body: serde_json::Value = test::read_body_json(resp).await;
     assert!(body.get("error").is_some());
     assert_eq!(put_mock.received_requests().await.len(), 1);
@@ -181,15 +207,19 @@ async fn reject_dangerous_filename() {
     let org_id = create_org(&pool, "Sanitize Org").await;
     let user_id = create_user(&pool, org_id, "san@example.com", "org_admin").await;
 
-    let result = Document::create(&pool, NewDocument {
-        org_id,
-        owner_id: user_id,
-        filename: "../evil.pdf".into(),
-        pages: 1,
-        is_target: false,
-        expires_at: None,
-        display_name: "evil.pdf".into(),
-    }).await;
+    let result = Document::create(
+        &pool,
+        NewDocument {
+            org_id,
+            owner_id: user_id,
+            filename: "../evil.pdf".into(),
+            pages: 1,
+            is_target: false,
+            expires_at: None,
+            display_name: "evil.pdf".into(),
+        },
+    )
+    .await;
 
     assert!(result.is_err());
 }
@@ -213,15 +243,20 @@ async fn reject_when_upload_quota_exceeded() {
         .await
         .unwrap();
 
-    Document::create(&pool, NewDocument {
-        org_id,
-        owner_id: user_id,
-        filename: "first.pdf".into(),
-        pages: 1,
-        is_target: true,
-        expires_at: None,
-        display_name: "first.pdf".into(),
-    }).await.unwrap();
+    Document::create(
+        &pool,
+        NewDocument {
+            org_id,
+            owner_id: user_id,
+            filename: "first.pdf".into(),
+            pages: 1,
+            is_target: true,
+            expires_at: None,
+            display_name: "first.pdf".into(),
+        },
+    )
+    .await
+    .unwrap();
 
     let pdf = "%PDF-1.5\n1 0 obj<<>>endobj\nstartxref\n0\n%%EOF";
     let boundary = "BOUNDARY";
@@ -229,11 +264,17 @@ async fn reject_when_upload_quota_exceeded() {
     let req = test::TestRequest::post()
         .uri(&format!("/api/upload?org_id={}&is_target=true", org_id))
         .insert_header((header::AUTHORIZATION, format!("Bearer {}", token)))
-        .insert_header((header::CONTENT_TYPE, format!("multipart/form-data; boundary={}", boundary)))
+        .insert_header((
+            header::CONTENT_TYPE,
+            format!("multipart/form-data; boundary={}", boundary),
+        ))
         .set_payload(body)
         .to_request();
     let resp = test::call_service(&app, req).await;
-    assert_eq!(resp.status(), actix_web::http::StatusCode::TOO_MANY_REQUESTS);
+    assert_eq!(
+        resp.status(),
+        actix_web::http::StatusCode::TOO_MANY_REQUESTS
+    );
 
     let count: (i64,) = sqlx::query_as("SELECT COUNT(*) FROM documents WHERE org_id=$1")
         .bind(org_id)
@@ -267,19 +308,37 @@ async fn reject_when_analysis_quota_exceeded() {
         .unwrap();
 
     let stages = serde_json::json!([{"type":"ocr"}]);
-    let pipeline = Pipeline::create(&pool, NewPipeline { org_id, name: "P".into(), stages }).await.unwrap();
+    let pipeline = Pipeline::create(
+        &pool,
+        NewPipeline {
+            org_id,
+            name: "P".into(),
+            stages,
+        },
+    )
+    .await
+    .unwrap();
 
     let pdf = "%PDF-1.5\n1 0 obj<<>>endobj\nstartxref\n0\n%%EOF";
     let boundary = "BOUNDARY";
     let body = multipart_body(boundary, "test.pdf", "application/pdf", pdf);
     let req = test::TestRequest::post()
-        .uri(&format!("/api/upload?org_id={}&pipeline_id={}&is_target=true", org_id, pipeline.id))
+        .uri(&format!(
+            "/api/upload?org_id={}&pipeline_id={}&is_target=true",
+            org_id, pipeline.id
+        ))
         .insert_header((header::AUTHORIZATION, format!("Bearer {}", token)))
-        .insert_header((header::CONTENT_TYPE, format!("multipart/form-data; boundary={}", boundary)))
+        .insert_header((
+            header::CONTENT_TYPE,
+            format!("multipart/form-data; boundary={}", boundary),
+        ))
         .set_payload(body)
         .to_request();
     let resp = test::call_service(&app, req).await;
-    assert_eq!(resp.status(), actix_web::http::StatusCode::TOO_MANY_REQUESTS);
+    assert_eq!(
+        resp.status(),
+        actix_web::http::StatusCode::TOO_MANY_REQUESTS
+    );
 
     let docs: (i64,) = sqlx::query_as("SELECT COUNT(*) FROM documents WHERE org_id=$1")
         .bind(org_id)
@@ -321,11 +380,17 @@ async fn cleanup_on_s3_upload_failure() {
     let req = test::TestRequest::post()
         .uri(&format!("/api/upload?org_id={}&is_target=true", org_id))
         .insert_header((header::AUTHORIZATION, format!("Bearer {}", token)))
-        .insert_header((header::CONTENT_TYPE, format!("multipart/form-data; boundary={}", boundary)))
+        .insert_header((
+            header::CONTENT_TYPE,
+            format!("multipart/form-data; boundary={}", boundary),
+        ))
         .set_payload(body)
         .to_request();
     let resp = test::call_service(&app, req).await;
-    assert_eq!(resp.status(), actix_web::http::StatusCode::INTERNAL_SERVER_ERROR);
+    assert_eq!(
+        resp.status(),
+        actix_web::http::StatusCode::INTERNAL_SERVER_ERROR
+    );
 
     let count: (i64,) = sqlx::query_as("SELECT COUNT(*) FROM documents WHERE org_id=$1")
         .bind(org_id)
@@ -335,4 +400,87 @@ async fn cleanup_on_s3_upload_failure() {
     assert_eq!(count.0, 0);
     assert_eq!(put_mock.received_requests().await.len(), 1);
     assert_eq!(delete_mock.received_requests().await.len(), 0);
+}
+
+#[actix_rt::test]
+async fn download_returns_presigned_url() {
+    let s3_server = MockServer::start().await;
+    let _put_mock = Mock::given(method("PUT"))
+        .respond_with(ResponseTemplate::new(200))
+        .mount_as_scoped(&s3_server)
+        .await;
+
+    let (app, pool) = setup_test_app(&s3_server).await;
+    let org_id = create_org(&pool, "Down Org").await;
+    let user_id = create_user(&pool, org_id, "down@example.com", "org_admin").await;
+    let token = generate_jwt_token(user_id, org_id, "org_admin");
+
+    let doc = Document::create(
+        &pool,
+        NewDocument {
+            org_id,
+            owner_id: user_id,
+            filename: "file.pdf".into(),
+            pages: 1,
+            is_target: false,
+            expires_at: None,
+            display_name: "file.pdf".into(),
+        },
+    )
+    .await
+    .unwrap();
+
+    let req = test::TestRequest::get()
+        .uri(&format!("/api/download/{}", doc.id))
+        .insert_header((header::AUTHORIZATION, format!("Bearer {}", token)))
+        .to_request();
+    let resp = test::call_service(&app, req).await;
+    assert!(resp.status().is_success());
+    let body: serde_json::Value = test::read_body_json(resp).await;
+    assert!(body.get("url").is_some());
+}
+
+#[actix_rt::test]
+async fn download_streams_local_file() {
+    let s3_server = MockServer::start().await;
+    let _put_mock = Mock::given(method("PUT"))
+        .respond_with(ResponseTemplate::new(200))
+        .mount_as_scoped(&s3_server)
+        .await;
+
+    let (app, pool) = setup_test_app(&s3_server).await;
+    let org_id = create_org(&pool, "Local Org").await;
+    let user_id = create_user(&pool, org_id, "local@example.com", "org_admin").await;
+    let token = generate_jwt_token(user_id, org_id, "org_admin");
+
+    let tempdir = tempfile::tempdir().unwrap();
+    std::env::set_var("LOCAL_S3_DIR", tempdir.path());
+    let path = tempdir.path().join("local.pdf");
+    tokio::fs::write(&path, b"%PDF-1.4\n1 0 obj<<>>endobj\nstartxref\n0\n%%EOF")
+        .await
+        .unwrap();
+
+    let doc = Document::create(
+        &pool,
+        NewDocument {
+            org_id,
+            owner_id: user_id,
+            filename: "local.pdf".into(),
+            pages: 1,
+            is_target: false,
+            expires_at: None,
+            display_name: "local.pdf".into(),
+        },
+    )
+    .await
+    .unwrap();
+
+    let req = test::TestRequest::get()
+        .uri(&format!("/api/download/{}", doc.id))
+        .insert_header((header::AUTHORIZATION, format!("Bearer {}", token)))
+        .to_request();
+    let resp = test::call_service(&app, req).await;
+    assert!(resp.status().is_success());
+    let body = test::read_body(resp).await;
+    assert!(!body.is_empty());
 }

--- a/docs/API_Examples.md
+++ b/docs/API_Examples.md
@@ -57,6 +57,21 @@ Status: `200 OK`
 - `429 Too Many Requests` – monthly quota exceeded.
 - `500 Internal Server Error` – failure while uploading or saving metadata.
 
+## Document Download
+
+### Request
+```http
+GET /api/download/<document_uuid>
+Authorization: Bearer <token>
+```
+
+### Success Response
+If `LOCAL_S3_DIR` is set, the PDF bytes are streamed directly with status `200 OK`.
+Otherwise the response contains a JSON object with a presigned URL:
+```json
+{"url": "https://s3.example.com/..."}
+```
+
 ## Pipeline Editor
 
 ### Create Pipeline

--- a/docs/Architecture.md
+++ b/docs/Architecture.md
@@ -43,6 +43,8 @@ List and download documents:
 GET /api/documents/{org_id}
 GET /api/download/{document_id}
 ```
+The download endpoint streams the PDF when `LOCAL_S3_DIR` is configured and
+otherwise returns a JSON object containing a presigned URL.
 
 ### Settings
 Organizations store quotas, AI/OCR configuration and prompt templates.

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -195,6 +195,18 @@ paths:
       responses:
         '200':
           description: Document uploaded
+  /download/{document_id}:
+    get:
+      summary: Download a document
+      parameters:
+        - name: document_id
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Document content or presigned URL
   /pipelines:
     post:
       summary: Create a pipeline


### PR DESCRIPTION
## Summary
- implement `/download/{document_id}` handler
- register route
- document new API in OpenAPI spec, examples and architecture docs
- test streaming from local storage and presigned URL generation

## Testing
- `cargo test --no-default-features` *(fails: Failed to connect to test database)*

------
https://chatgpt.com/codex/tasks/task_e_686943fff4cc83339f633027b434d84d