### PR TITLE
Add email invite failure path test

### DIFF
--- a/backend/src/email.rs
+++ b/backend/src/email.rs
@@ -1,5 +1,8 @@
 use lettre::message::{header, Mailbox, Message};
-use lettre::{AsyncSmtpTransport, Tokio1Executor, transport::smtp::authentication::Credentials, AsyncTransport};
+use lettre::{
+    transport::smtp::authentication::Credentials, AsyncSmtpTransport, AsyncTransport,
+    Tokio1Executor,
+};
 use once_cell::sync::Lazy;
 use std::env;
 
@@ -9,13 +12,19 @@ static MAILER: Lazy<Option<AsyncSmtpTransport<Tokio1Executor>>> = Lazy::new(|| {
     let user = env::var("SMTP_USERNAME").ok()?;
     let pass = env::var("SMTP_PASSWORD").ok()?;
     let creds = Credentials::new(user, pass);
-    Some(AsyncSmtpTransport::<Tokio1Executor>::relay(&server).ok()?
-        .port(port)
-        .credentials(creds)
-        .build())
+    Some(
+        AsyncSmtpTransport::<Tokio1Executor>::relay(&server)
+            .ok()?
+            .port(port)
+            .credentials(creds)
+            .build(),
+    )
 });
 
 pub async fn send_email(to: &str, subject: &str, body: &str) -> anyhow::Result<()> {
+    if std::env::var("MOCK_EMAIL_FAIL").is_ok() {
+        return Err(anyhow::anyhow!("mock email failure"));
+    }
     if let Some(mailer) = MAILER.as_ref() {
         let from = env::var("SMTP_FROM").unwrap_or_else(|_| "noreply@example.com".into());
         let email = Message::builder()


### PR DESCRIPTION
## Summary
- simulate email sending failure with environment variable
- add test for admin invite email failure path

## Testing
- `cargo clippy --all-targets`
- `cargo test --test admin_invite_tests -- --nocapture` *(fails: PoolTimedOut)*

------
https://chatgpt.com/codex/tasks/task_e_68694404e1088333b51859d7f8a13327