### PR TITLE
Improve error logging in handlers

### DIFF
--- a/backend/src/email.rs
+++ b/backend/src/email.rs
@@ -40,7 +40,6 @@ async fn deliver_email(to: &str, subject: &str, body: &str) -> anyhow::Result<()
             .send()
             .await?;
         return Ok(());
-´
     }
     if let Some(mailer) = MAILER.as_ref() {
         let from = env::var("SMTP_FROM").unwrap_or_else(|_| "noreply@example.com".into());

--- a/backend/src/error.rs
+++ b/backend/src/error.rs
@@ -13,6 +13,18 @@ impl ApiError {
     pub fn new<M: Into<String>>(message: M, status: StatusCode) -> Self {
         Self { message: message.into(), status }
     }
+
+    /// Helper for wrapping database related errors.
+    pub fn from_db<E: std::fmt::Debug>(msg: &str, err: E) -> Self {
+        log::error!("Database error: {:?}", err);
+        Self::new(msg, StatusCode::INTERNAL_SERVER_ERROR)
+    }
+
+    /// Helper for wrapping S3/storage related errors.
+    pub fn from_s3<E: std::fmt::Debug>(msg: &str, err: E) -> Self {
+        log::error!("S3 error: {:?}", err);
+        Self::new(msg, StatusCode::INTERNAL_SERVER_ERROR)
+    }
 }
 
 impl fmt::Display for ApiError {

--- a/backend/src/handlers/auth.rs
+++ b/backend/src/handlers/auth.rs
@@ -42,7 +42,11 @@ pub async fn register(data: web::Json<RegisterInput>, pool: web::Data<PgPool>) -
         Ok(ph) => ph.to_string(),
         Err(e) => {
             log::error!("Password hash error: {:?}", e);
-            return HttpResponse::InternalServerError().json(serde_json::json!({"error": "Failed to register user."}));
+            return ApiError::new(
+                "Failed to register user.",
+                StatusCode::INTERNAL_SERVER_ERROR,
+            )
+            .error_response();
         }
     };
     let new_user_role = data.role.clone().unwrap_or_else(|| "user".to_string());
@@ -79,7 +83,7 @@ pub async fn register(data: web::Json<RegisterInput>, pool: web::Data<PgPool>) -
                     return HttpResponse::Conflict().json(serde_json::json!({"error": "Email address already in use."}));
                 }
             }
-            HttpResponse::InternalServerError().json(serde_json::json!({"error": "Failed to register user."}))
+            ApiError::from_db("Failed to register user.", e).error_response()
         }
     }
 }

--- a/backend/src/handlers/document.rs
+++ b/backend/src/handlers/document.rs
@@ -3,8 +3,9 @@ use crate::models::{
     AnalysisJob, Document, DocumentError, NewAnalysisJob, NewDocument, OrgSettings,
 };
 use crate::utils::log_action;
+use crate::error::ApiError;
 use actix_multipart::Multipart;
-use actix_web::{get, post, web, HttpResponse};
+use actix_web::{get, post, web, HttpResponse, ResponseError};
 use anyhow::Error;
 use async_trait::async_trait;
 use aws_sdk_s3::{presigning::PresigningConfig, Client};
@@ -115,21 +116,20 @@ async fn upload_to_s3(
     bucket: &str,
     key: &str,
     bytes: Vec<u8>,
-) -> Result<(), HttpResponse> {
-    if s3
+) -> Result<(), ApiError> {
+    match s3
         .put_object()
         .bucket(bucket)
         .key(key)
         .body(bytes.into())
         .send()
         .await
-        .is_err()
     {
-        log::error!("Failed to upload {} to S3 bucket {}", key, bucket);
-        Err(HttpResponse::InternalServerError()
-            .json(serde_json::json!({"error": "File upload to storage failed."})))
-    } else {
-        Ok(())
+        Ok(_) => Ok(()),
+        Err(e) => Err(ApiError::from_s3(
+            "File upload to storage failed.",
+            e,
+        )),
     }
 }
 
@@ -294,8 +294,8 @@ pub async fn upload(
     let sanitized_filename_part = sanitize_filename::sanitize(&base_filename);
     let s3_key_name = format!("{}-{}", Uuid::new_v4(), sanitized_filename_part);
 
-    if let Err(resp) = upload_to_s3(s3.get_ref(), &bucket, &s3_key_name, bytes_data.clone()).await {
-        return resp;
+    if let Err(err) = upload_to_s3(s3.get_ref(), &bucket, &s3_key_name, bytes_data.clone()).await {
+        return err.error_response();
     }
 
     let doc_to_create = NewDocument {
@@ -319,16 +319,14 @@ pub async fn upload(
             return HttpResponse::BadRequest()
                 .json(serde_json::json!({"error": "Invalid filename."}));
         }
-        Err(DocumentError::Sqlx(e)) => {
-            log::error!(
-                "Failed to create document record for S3 key {}: {:?}",
-                s3_key_name,
-                e
-            );
-            cleanup_s3_object(s3.get_ref(), &bucket, &s3_key_name).await;
-            return HttpResponse::InternalServerError()
-                .json(serde_json::json!({"error": "Failed to save document information."}));
-        }
+            Err(DocumentError::Sqlx(e)) => {
+                cleanup_s3_object(s3.get_ref(), &bucket, &s3_key_name).await;
+                return ApiError::from_db(
+                    "Failed to save document information.",
+                    e,
+                )
+                .error_response();
+            }
     };
 
     log_action(
@@ -375,14 +373,12 @@ pub async fn upload(
                 }
             }
             Err(e) => {
-                log::error!(
-                    "Failed to create analysis job for document {}: {:?}",
-                    created_document.id,
-                    e
-                );
                 cleanup_s3_object(s3.get_ref(), &bucket, &s3_key_name).await;
-                return HttpResponse::InternalServerError()
-                    .json(serde_json::json!({"error": "Failed to queue analysis job."}));
+                return ApiError::from_db(
+                    "Failed to queue analysis job.",
+                    e,
+                )
+                .error_response();
             }
         }
     }
@@ -409,8 +405,7 @@ pub async fn download(
         Ok(Some(d)) => d,
         Ok(None) => return HttpResponse::NotFound().finish(),
         Err(e) => {
-            log::error!("Failed to fetch document {}: {:?}", document_id, e);
-            return HttpResponse::InternalServerError().finish();
+            return ApiError::from_db("Failed to fetch document.", e).error_response();
         }
     };
 
@@ -434,26 +429,18 @@ pub async fn download(
                     format!("attachment; filename=\"{}\"", doc.display_name),
                 ))
                 .body(bytes),
-            Err(e) => {
-                log::error!(
-                    "Failed to read local file for document {}: {:?}",
-                    document_id,
-                    e
-                );
-                HttpResponse::InternalServerError().finish()
-            }
+            Err(e) => ApiError::from_s3("Failed to read local file", e).error_response(),
         }
     } else {
         let bucket = std::env::var("S3_BUCKET").unwrap_or_else(|_| "uploads".into());
         let presign_cfg = match PresigningConfig::expires_in(Duration::from_secs(3600)) {
             Ok(cfg) => cfg,
             Err(e) => {
-                log::error!(
-                    "Failed to create presign config for {}: {:?}",
-                    document_id,
-                    e
-                );
-                return HttpResponse::InternalServerError().finish();
+                return ApiError::from_s3(
+                    "Failed to create presign config",
+                    e,
+                )
+                .error_response();
             }
         };
         match s3
@@ -464,10 +451,7 @@ pub async fn download(
             .await
         {
             Ok(req) => HttpResponse::Ok().json(serde_json::json!({"url": req.uri().to_string()})),
-            Err(e) => {
-                log::error!("Failed to presign document {}: {:?}", document_id, e);
-                HttpResponse::InternalServerError().finish()
-            }
+            Err(e) => ApiError::from_s3("Failed to presign document", e).error_response(),
         }
     }
 }


### PR DESCRIPTION
## Summary
- add DB/S3 helpers to ApiError
- improve error handling in auth and document handlers
- fix stray accent char in email helper

## Testing
- `cargo test --no-run`

------
https://chatgpt.com/codex/tasks/task_e_68694ab31e9c8333b19f8990f1b80851