### PR TITLE
Add example test env setup

### DIFF
--- a/backend/.env.test.example
+++ b/backend/.env.test.example
@@ -1,0 +1,9 @@
+DATABASE_URL_TEST=postgres://postgres:postgres@localhost/testdb
+REDIS_URL=redis://localhost/
+REDIS_RATE_LIMIT_FALLBACK=memory # memory|deny|allow
+S3_BUCKET=uploads
+AWS_ENDPOINT=http://localhost:9000
+AWS_ACCESS_KEY=minioadmin
+AWS_SECRET_KEY=minioadmin
+JWT_SECRET=changeme
+

--- a/backend/tests/README.md
+++ b/backend/tests/README.md
@@ -1,0 +1,16 @@
+# Running Backend Tests
+
+The integration tests load environment variables from `../.env.test`.
+Create this file based on `.env.test.example` before running `cargo test`.
+
+At a minimum set `DATABASE_URL_TEST` to point to a PostgreSQL database used only
+for tests. Some tests also use `REDIS_URL` for Redis-based rate limiting. Other
+values from `.env.example` may be included as needed.
+
+Example setup:
+
+```bash
+cp ../.env.test.example ../.env.test
+cargo test --manifest-path ../Cargo.toml
+```
+

--- a/scripts/setup_dev.sh
+++ b/scripts/setup_dev.sh
@@ -6,6 +6,12 @@ if [ ! -f backend/.env ]; then
   cp backend/.env.example backend/.env
 fi
 
+# Ensure test environment file exists for integration tests
+if [ ! -f backend/.env.test ]; then
+  echo "Copying backend/.env.test"
+  cp backend/.env.test.example backend/.env.test
+fi
+
 ./scripts/bootstrap_deps.sh
 
 echo "Running migrations..."


### PR DESCRIPTION
## Summary
- add README to backend integration tests folder with env setup notes
- provide `.env.test.example` file
- auto-generate `.env.test` in `scripts/setup_dev.sh`

## Testing
- `cargo test --manifest-path backend/Cargo.toml --no-run` *(fails: build aborted)*

------
https://chatgpt.com/codex/tasks/task_e_68694ab592f483339723321c31e374b9