### PR TITLE
Update security docs

### DIFF
--- a/docs/Security.md
+++ b/docs/Security.md
@@ -7,7 +7,16 @@ For production deployments generate unique credentials instead of relying on the
 
 ### Recommended production values
 
+- **`JWT_SECRET`** – generate a 256‑bit value for signing tokens. Example:
+  ```bash
+  openssl rand -hex 32 # => e1c0c1d2edb1af378b90d593ca110ec3d3f211ba6f9e9ff5ca0a8f97b2f53811
+  ```
+  Use the same secret on all backend instances so issued JWTs remain valid.
 - **`CSRF_TOKEN`** – set this to a high‑entropy random string such as the output of `openssl rand -hex 32`. When present the backend rejects requests whose `X-CSRF-Token` header does not match this value.
 - **Secure cookies** – the login cookie is flagged `HttpOnly` and `SameSite=Lax` by default. The `Secure` flag is automatically enabled when `BASE_URL` starts with `https://`. Ensure `BASE_URL` and `FRONTEND_ORIGIN` use HTTPS in production so cookies are transmitted only over TLS.
-- **Rate limiting** – provide a production Redis instance via `REDIS_URL`. Set `REDIS_RATE_LIMIT_FALLBACK=deny` so that API requests are rejected if Redis becomes unavailable instead of falling back to the in‑memory limiter.
+- **HTTPS only** – terminate TLS in a reverse proxy or load balancer and always access the API via `https://`. This protects JWTs and session cookies in transit.
+- **Rate limiting** – provide a production Redis instance via `REDIS_URL`. Set `REDIS_RATE_LIMIT_FALLBACK=deny` so that API requests are rejected if Redis becomes unavailable instead of falling back to the in-memory limiter.
 
+### Updating API keys
+
+The settings endpoints mask sensitive keys. When retrieving settings the fields `ai_api_key` and `ocr_api_key` appear as `********`. To keep an existing key send the masked value back unchanged. Provide a new value to rotate the key or send an empty string to clear it. See `backend/src/handlers/settings.rs` for the implementation.


### PR DESCRIPTION
## Summary
- document strong JWT/CSRF secret values
- mention HTTPS-only deployments
- explain how masked API keys can be rotated via settings.rs

## Testing
- `cargo test --manifest-path backend/Cargo.toml` *(fails: unknown start of token in email.rs)*
- `npm test --prefix frontend` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68694ab7f3f083338ab3a2c2c50f3252