### PR TITLE
Add backend k8s limits and secret manifests

### DIFF
--- a/docs/Deployment.md
+++ b/docs/Deployment.md
@@ -31,9 +31,16 @@ kubectl create secret generic backend-env \
   --from-literal=DATABASE_URL=postgres://user:pass@db/production \
   --from-literal=JWT_SECRET=$(openssl rand -hex 32) \
   --from-literal=S3_BUCKET=uploads
-
 kubectl create secret generic frontend-env \
   --from-literal=PUBLIC_BACKEND_URL=https://example.com
+```
+
+Equivalent manifest files `k8s/backend-secret.yaml` and
+`k8s/frontend-secret.yaml` are provided for declarative deployments:
+
+```bash
+kubectl apply -f k8s/backend-secret.yaml
+kubectl apply -f k8s/frontend-secret.yaml
 ```
 
 Set the `REGISTRY` secret in your CI settings so images are pushed to your container registry.
@@ -68,6 +75,8 @@ spec:
             port:
               number: 80
 ```
+
+This manifest is also available as `k8s/backend-ingress.yaml`.
 
 ### Example Traefik ingress
 

--- a/k8s/backend-deployment.yaml
+++ b/k8s/backend-deployment.yaml
@@ -20,6 +20,13 @@ spec:
             name: backend-env
         ports:
         - containerPort: 8080
+        resources:
+          requests:
+            cpu: "200m"
+            memory: "256Mi"
+          limits:
+            cpu: "1"
+            memory: "512Mi"
         livenessProbe:
           httpGet:
             path: /api/health

--- a/k8s/backend-ingress.yaml
+++ b/k8s/backend-ingress.yaml
@@ -1,0 +1,22 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: backend-ingress
+  annotations:
+    nginx.ingress.kubernetes.io/force-ssl-redirect: "true"
+spec:
+  tls:
+  - hosts:
+    - example.com
+    secretName: tls-secret
+  rules:
+  - host: example.com
+    http:
+      paths:
+      - path: /
+        pathType: Prefix
+        backend:
+          service:
+            name: backend
+            port:
+              number: 80

--- a/k8s/backend-secret.yaml
+++ b/k8s/backend-secret.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: backend-env
+type: Opaque
+stringData:
+  DATABASE_URL: postgres://user:pass@db/production
+  JWT_SECRET: change_me
+  AWS_ENDPOINT: https://s3.example.com
+  AWS_ACCESS_KEY: access_key
+  AWS_SECRET_KEY: secret_key
+  S3_BUCKET: uploads
+  FRONTEND_ORIGIN: https://example.com
+  REDIS_URL: redis://redis:6379/
+  AI_API_URL: https://ai.example.com
+  AI_API_KEY: your-api-key

--- a/k8s/frontend-secret.yaml
+++ b/k8s/frontend-secret.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: frontend-env
+type: Opaque
+stringData:
+  PUBLIC_BACKEND_URL: https://example.com


### PR DESCRIPTION
## Summary
- add CPU/memory limits to backend Deployment
- provide backend/frontend Secret manifests
- include an example Ingress manifest
- document applying Secret manifests and Ingress file

## Testing
- `cargo test --manifest-path backend/Cargo.toml --no-run` *(fails: unknown start of token)*

------
https://chatgpt.com/codex/tasks/task_e_68694ab8c9b483338abb894ecec1a9d0