### PR TITLE
Add idle worker shutdown log and metric

### DIFF
--- a/backend/src/bin/worker.rs
+++ b/backend/src/bin/worker.rs
@@ -218,7 +218,7 @@ async fn main() -> Result<()> {
             None => {
                 if let Some(d) = idle_duration {
                     if last_activity.elapsed() >= d {
-                        info!("Idle timeout reached, shutting down");
+                        worker::log_idle_shutdown();
                         break 'outer;
                     }
                 }

--- a/backend/src/worker/metrics.rs
+++ b/backend/src/worker/metrics.rs
@@ -1,6 +1,8 @@
 use actix_web::{web, App, HttpResponse, HttpServer};
 use once_cell::sync::Lazy;
-use prometheus::{Encoder, HistogramVec, IntCounterVec, Registry, TextEncoder};
+use prometheus::{
+    Encoder, HistogramVec, IntCounterVec, IntCounter, Registry, TextEncoder,
+};
 
 pub static REGISTRY: Lazy<Registry> = Lazy::new(Registry::new);
 
@@ -54,6 +56,16 @@ pub static API_ERROR_COUNTER: Lazy<IntCounterVec> = Lazy::new(|| {
         "Total failed AI or OCR API calls",
     );
     let counter = IntCounterVec::new(opts, &["service"]).unwrap();
+    REGISTRY.register(Box::new(counter.clone())).unwrap();
+    counter
+});
+
+pub static WORKER_SHUTDOWN_COUNTER: Lazy<IntCounter> = Lazy::new(|| {
+    let opts = prometheus::Opts::new(
+        "worker_shutdowns_total",
+        "Total number of worker shutdowns",
+    );
+    let counter = IntCounter::with_opts(opts).unwrap();
     REGISTRY.register(Box::new(counter.clone())).unwrap();
     counter
 });

--- a/backend/src/worker/mod.rs
+++ b/backend/src/worker/mod.rs
@@ -26,7 +26,7 @@ pub mod report;
 
 use aws_sdk_s3::primitives::ByteStream;
 use aws_sdk_s3::Client as S3Client;
-use crate::worker::metrics::S3_ERROR_COUNTER;
+use crate::worker::metrics::{S3_ERROR_COUNTER, WORKER_SHUTDOWN_COUNTER};
 use std::env;
 use std::path::PathBuf;
 use tokio::time::{sleep, Duration};
@@ -111,4 +111,10 @@ pub async fn save_stage_output(
     JobStageOutput::create(pool, rec).await?;
     tracing::info!(job_id=%job_id, stage=%stage_name, "stage output saved");
     Ok(())
+}
+
+/// Log that the worker shuts down after being idle and update metrics.
+pub fn log_idle_shutdown() {
+    tracing::info!("Idle timeout reached, shutting down");
+    WORKER_SHUTDOWN_COUNTER.inc();
 }

--- a/docs/Monitoring.md
+++ b/docs/Monitoring.md
@@ -1,6 +1,6 @@
 # Monitoring
 
-The backend exposes Prometheus metrics at `http://localhost:9100/metrics`. To visualize these metrics, run Grafana with a preconfigured dashboard. In addition to job and stage metrics, the exporter collects S3 error counts (`s3_errors_total`), job duration histograms (`job_duration_seconds`), OCR latency histograms (`ocr_duration_seconds`), failed AI/OCR calls (`ai_ocr_errors_total`), login failure counts (`login_failures_total`), and rate limit fallback events (`rate_limit_fallback_total`).
+The backend exposes Prometheus metrics at `http://localhost:9100/metrics`. To visualize these metrics, run Grafana with a preconfigured dashboard. In addition to job and stage metrics, the exporter collects S3 error counts (`s3_errors_total`), job duration histograms (`job_duration_seconds`), OCR latency histograms (`ocr_duration_seconds`), failed AI/OCR calls (`ai_ocr_errors_total`), login failure counts (`login_failures_total`), rate limit fallback events (`rate_limit_fallback_total`), and worker shutdown counts (`worker_shutdowns_total`).
 
 ## docker-compose example
 


### PR DESCRIPTION
## Summary
- add worker shutdown metric and idle log helper
- emit shutdown info from worker loop
- document new `worker_shutdowns_total` metric

## Testing
- `cargo test --manifest-path backend/Cargo.toml --all-targets --no-run`

------
https://chatgpt.com/codex/tasks/task_e_68695926f9ac83339ef07a085084ae5e