### PR TITLE
Add event handling tests for frontend components

### DIFF
--- a/frontend/src/lib/components/__tests__/DocumentList.events.test.ts
+++ b/frontend/src/lib/components/__tests__/DocumentList.events.test.ts
@@ -1,0 +1,54 @@
+import { render, waitFor, fireEvent } from '@testing-library/svelte';
+import { expect, test, vi } from 'vitest';
+import DocumentList from '../DocumentList.svelte';
+
+const fetchMock = vi.fn((url: string) => {
+  if (url.startsWith('/api/download/')) {
+    return Promise.resolve({
+      ok: true,
+      json: async () => ({ url: 'http://example.com/file.pdf' })
+    });
+  }
+  return Promise.resolve({
+    ok: true,
+    json: async () => ({
+      items: [
+        {
+          id: '1',
+          filename: 'doc1.pdf',
+          display_name: 'Doc One',
+          is_target: true,
+          upload_date: '2023-01-01T00:00:00Z'
+        }
+      ],
+      page: 1,
+      total_items: 1,
+      per_page: 10,
+      total_pages: 1,
+      sort_by: 'upload_date',
+      sort_order: 'desc'
+    })
+  });
+}) as any;
+
+vi.stubGlobal('fetch', fetchMock);
+
+
+// window.open is not global open? It's window.open
+const openSpy = vi.spyOn(window, 'open').mockImplementation(() => null);
+
+// Test download button triggers API call and opens link
+
+test('download button uses API and opens link', async () => {
+  const { getByText } = render(DocumentList, { props: { orgId: 'org1' } });
+
+  await waitFor(() => expect(getByText('Doc One')).toBeInTheDocument());
+
+  await fireEvent.click(getByText('Download'));
+
+  await waitFor(() => {
+    expect(fetchMock).toHaveBeenCalledWith('/api/download/1', { credentials: 'include' });
+    expect(openSpy).toHaveBeenCalledWith('http://example.com/file.pdf', '_blank');
+  });
+});
+

--- a/frontend/src/lib/components/__tests__/PipelineEditor.events.test.ts
+++ b/frontend/src/lib/components/__tests__/PipelineEditor.events.test.ts
@@ -1,0 +1,51 @@
+import { render, fireEvent } from '@testing-library/svelte';
+import { tick } from 'svelte';
+import { expect, test, vi, beforeEach } from 'vitest';
+import PipelineEditor from '../PipelineEditor.svelte';
+import * as apiUtils from '$lib/utils/apiUtils';
+
+const apiFetch = vi.spyOn(apiUtils, 'apiFetch');
+
+vi.stubGlobal('alert', vi.fn());
+vi.stubGlobal('confirm', vi.fn(() => true));
+
+const initialPipeline = { id: 'p1', name: 'Test', org_id: 'org1', stages: [{ id: 's1', type: 'parse', config: { strategy: 'Passthrough', parameters: {} } }] };
+
+beforeEach(() => {
+  apiFetch.mockResolvedValue({ ok: true, json: async () => ({ prompt_templates: [] }) });
+  apiFetch.mockClear();
+});
+
+test('dispatches pipelinesUpdated and saved on save', async () => {
+  const pipelinesUpdated = vi.fn();
+  document.body.addEventListener('pipelinesUpdated', pipelinesUpdated);
+  const { getByText, component } = render(PipelineEditor, { props: { orgId: 'org1', initialPipeline } });
+  const saved = vi.fn();
+  component.$on('saved', saved);
+
+  await tick();
+  await fireEvent.click(getByText('Save'));
+  await tick();
+
+  expect(pipelinesUpdated).toHaveBeenCalled();
+  expect(saved).toHaveBeenCalled();
+
+  document.body.removeEventListener('pipelinesUpdated', pipelinesUpdated);
+});
+
+test('dispatches pipelinesUpdated and saved on delete', async () => {
+  const pipelinesUpdated = vi.fn();
+  document.body.addEventListener('pipelinesUpdated', pipelinesUpdated);
+  const { getByText, component } = render(PipelineEditor, { props: { orgId: 'org1', initialPipeline } });
+  const saved = vi.fn();
+  component.$on('saved', saved);
+
+  await tick();
+  await fireEvent.click(getByText('Delete'));
+  await tick();
+
+  expect(pipelinesUpdated).toHaveBeenCalled();
+  expect(saved).toHaveBeenCalled();
+
+  document.body.removeEventListener('pipelinesUpdated', pipelinesUpdated);
+});


### PR DESCRIPTION
## Summary
- test DocumentList download button dispatches fetch and opens link
- test PipelineEditor emits pipelinesUpdated on save and delete

## Testing
- `npm test --silent`
- `npx vitest run`


------
https://chatgpt.com/codex/tasks/task_e_68698d2454008333a8713279024fc313