### PR TITLE
Add worker service helper

### DIFF
--- a/deploy/worker.service
+++ b/deploy/worker.service
@@ -1,0 +1,13 @@
+[Unit]
+Description=crPipeline Worker Service
+After=network.target
+
+[Service]
+Type=simple
+WorkingDirectory=/opt/crPipeline
+ExecStart=/opt/crPipeline/scripts/worker_service.sh
+Restart=always
+User=crpipeline
+
+[Install]
+WantedBy=multi-user.target

--- a/docs/Todo-fuer-User.md
+++ b/docs/Todo-fuer-User.md
@@ -1,0 +1,22 @@
+# Worker als systemd-Dienst
+
+Dieses Dokument beschreibt kurz, wie der Background-Worker als Dienst eingerichtet wird. Die Anleitung wird zukünftig weiter ausgebaut.
+
+1. Worker-Binary erstellen:
+   ```bash
+   cargo build --release --bin worker --features worker-bin
+   ```
+2. Dateien kopieren (Pfad bei Bedarf anpassen):
+   ```bash
+   sudo mkdir -p /opt/crPipeline/scripts
+   sudo cp scripts/worker_service.sh /opt/crPipeline/scripts/
+   sudo cp deploy/worker.service /etc/systemd/system/worker.service
+   sudo chmod +x /opt/crPipeline/scripts/worker_service.sh
+   ```
+   Der Service erwartet das Projekt unter `/opt/crPipeline`. Passe den Pfad in
+   der Unit-Datei an, falls es woanders liegt.
+3. Service aktivieren:
+   ```bash
+   sudo systemctl daemon-reload
+   sudo systemctl enable --now worker.service
+   ```

--- a/scripts/worker_service.sh
+++ b/scripts/worker_service.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+# Start the worker binary after loading environment variables.
+set -e
+
+# Run from repository root
+cd "$(dirname "$0")/.."
+
+ENV_FILE=${ENV_FILE:-backend/.env}
+if [ ! -f "$ENV_FILE" ]; then
+  echo "$ENV_FILE not found" >&2
+  exit 1
+fi
+
+set -a
+source "$ENV_FILE"
+set +a
+
+exec ./target/release/worker


### PR DESCRIPTION
## Summary
- add script to run worker with `.env`
- provide example `worker.service`
- document systemd installation steps in `docs/Todo-fuer-User.md`

## Testing
- `cargo --version`
- `npm --version`
- `cargo test` *(fails: build requires network access and dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68698d2530d88333a65b7ab160e45ad1