### PR TITLE
Implement apiFetch wrapper with CSRF token

### DIFF
--- a/frontend/src/App.svelte
+++ b/frontend/src/App.svelte
@@ -9,6 +9,7 @@
   import Button from './lib/components/Button.svelte';
   import OrgAdmin from './lib/components/OrgAdmin.svelte';
   import { onMount } from 'svelte';
+  import { apiFetch } from '$lib/utils/apiUtils';
 
   let loggedIn = false;
   let org: string | null = null;
@@ -105,37 +106,31 @@
   setContext('viewJobDetails', viewJobDetails);
   
   async function checkAuth() {
-    const res = await fetch('/api/me');
-    if (res.ok) {
+    try {
+      const res = await apiFetch('/api/me');
       const data = await res.json();
       org = data.org_id;
       userId = data.user_id;
       role = data.role;
       loggedIn = true;
-    } else {
+    } catch {
       loggedIn = false;
     }
   }
 
   async function loadData() {
     if (!org) return;
-    const res = await fetch(`/api/documents/${org}`);
-    if (res.ok) {
-      docs = await res.json();
-    }
-    const jobRes = await fetch(`/api/jobs/${org}`);
-    if (jobRes.ok) {
-      jobs = await jobRes.json();
-    }
+    const res = await apiFetch(`/api/documents/${org}`);
+    docs = await res.json();
+    const jobRes = await apiFetch(`/api/jobs/${org}`);
+    jobs = await jobRes.json();
   }
 
   async function loadSettings() {
     if (!org) return;
-    const res = await fetch(`/api/settings/${org}`);
-    if (res.ok) {
-      const data = await res.json();
-      document.documentElement.style.setProperty('--color-accent', data.accent_color);
-    }
+    const res = await apiFetch(`/api/settings/${org}`);
+    const data = await res.json();
+    document.documentElement.style.setProperty('--color-accent', data.accent_color);
   }
 
   onMount(async () => {

--- a/frontend/src/lib/components/AnalysisJobDetail.svelte
+++ b/frontend/src/lib/components/AnalysisJobDetail.svelte
@@ -4,6 +4,7 @@
   import Button from './Button.svelte';
   import Modal from './Modal.svelte';
   import * as Diff from 'diff'; // Import the diff library
+  import { apiFetch } from '$lib/utils/apiUtils';
 
   export let jobId: string;
 
@@ -98,14 +99,7 @@
     isLoading = true;
     error = null;
     try {
-      const response = await fetch(`/api/jobs/${id}/details`);
-      if (!response.ok) {
-        if (response.status === 404) {
-          throw new Error(`Job with ID ${id} not found.`);
-        }
-        const errorData = await response.json().catch(() => ({ error: `HTTP error ${response.status} - ${response.statusText}` }));
-        throw new Error(errorData.error || `Failed to fetch job details: ${response.statusText}`);
-      }
+      const response = await apiFetch(`/api/jobs/${id}/details`);
       const data: JobDetails = await response.json();
       jobDetails = data;
 
@@ -219,7 +213,7 @@
             console.info(`Using pre-loaded OCR text for comparison: ${ocrOutputToDisplay.stage_name}`);
         } else if (ocrOutputToDisplay) { // Ensure metadata exists before fetching
             console.info(`Fetching OCR text for comparison: ${ocrOutputToDisplay.stage_name}`);
-            const presignedUrlResponse = await fetch(`/api/jobs/outputs/${ocrOutputToDisplay.id}/download_url`);
+            const presignedUrlResponse = await apiFetch(`/api/jobs/outputs/${ocrOutputToDisplay.id}/download_url`);
             if (!presignedUrlResponse.ok) { success = false; throw new Error(`OCR Text (Compare): ${ (await presignedUrlResponse.json().catch(() => ({}))).error || presignedUrlResponse.statusText }`); }
             const presignedUrlData = await presignedUrlResponse.json();
             if (!presignedUrlData.url) { success = false; throw new Error("OCR Text URL (Compare) not found."); }
@@ -235,7 +229,7 @@
             console.info(`Using pre-loaded Parse JSON for comparison: ${parseOutputToDisplay.stage_name}`);
         } else if (parseOutputToDisplay) { // Ensure metadata exists before fetching
             console.info(`Fetching Parse JSON for comparison: ${parseOutputToDisplay.stage_name}`);
-            const presignedUrlResponse = await fetch(`/api/jobs/outputs/${parseOutputToDisplay.id}/download_url`);
+            const presignedUrlResponse = await apiFetch(`/api/jobs/outputs/${parseOutputToDisplay.id}/download_url`);
             if (!presignedUrlResponse.ok) { success = false; throw new Error(`Parse JSON (Compare): ${ (await presignedUrlResponse.json().catch(() => ({}))).error || presignedUrlResponse.statusText }`); }
             const presignedUrlData = await presignedUrlResponse.json();
             if (!presignedUrlData.url) { success = false; throw new Error("Parse JSON URL (Compare) not found."); }
@@ -300,7 +294,7 @@
 
     try {
       // Fetch AI Input
-      let presignedUrlResponse = await fetch(`/api/jobs/outputs/${aiInputStageOutputMetadata.id}/download_url`);
+      let presignedUrlResponse = await apiFetch(`/api/jobs/outputs/${aiInputStageOutputMetadata.id}/download_url`);
       if (!presignedUrlResponse.ok) throw new Error(`AI Input: ${ (await presignedUrlResponse.json().catch(() => ({}))).error || presignedUrlResponse.statusText }`);
       let presignedUrlData = await presignedUrlResponse.json();
       if (!presignedUrlData.url) throw new Error("AI Input URL not found.");
@@ -316,7 +310,7 @@
       aiInputJsonForDiff = tempAiInputJson; // Store for copy button
 
       // Fetch AI Output
-      presignedUrlResponse = await fetch(`/api/jobs/outputs/${aiOutputStageOutputMetadata.id}/download_url`);
+      presignedUrlResponse = await apiFetch(`/api/jobs/outputs/${aiOutputStageOutputMetadata.id}/download_url`);
       if (!presignedUrlResponse.ok) throw new Error(`AI Output: ${ (await presignedUrlResponse.json().catch(() => ({}))).error || presignedUrlResponse.statusText }`);
       presignedUrlData = await presignedUrlResponse.json();
       if (!presignedUrlData.url) throw new Error("AI Output URL not found.");
@@ -384,7 +378,7 @@
     setOutputToDisplay(output);
 
     try {
-      const presignedUrlResponse = await fetch(`/api/jobs/outputs/${output.id}/download_url`);
+      const presignedUrlResponse = await apiFetch(`/api/jobs/outputs/${output.id}/download_url`);
       if (!presignedUrlResponse.ok) {
         const errorData = await presignedUrlResponse.json().catch(() => ({}));
         throw new Error(errorData.error || `Failed to get JSON URL (${output.stage_name}): ${presignedUrlResponse.statusText}`);
@@ -444,7 +438,7 @@
     ocrOutputToDisplay = output;
 
     try {
-      const presignedUrlResponse = await fetch(`/api/jobs/outputs/${output.id}/download_url`);
+      const presignedUrlResponse = await apiFetch(`/api/jobs/outputs/${output.id}/download_url`);
       if (!presignedUrlResponse.ok) {
         const errorData = await presignedUrlResponse.json().catch(() => ({}));
         throw new Error(errorData.error || `Failed to get OCR text URL: ${presignedUrlResponse.statusText}`);
@@ -479,7 +473,7 @@
     viewingOutputTitle = `Output: ${output.stage_name} (${output.output_type})`;
 
     try {
-      const presignedUrlResponse = await fetch(`/api/jobs/outputs/${output.id}/download_url`);
+      const presignedUrlResponse = await apiFetch(`/api/jobs/outputs/${output.id}/download_url`);
       if (!presignedUrlResponse.ok) {
         const errorData = await presignedUrlResponse.json().catch(() => ({}));
         throw new Error(errorData.error || `Failed to get view URL: ${presignedUrlResponse.statusText}`);
@@ -533,7 +527,7 @@
 
   async function downloadStageOutput(outputId: string, filenameSuggestion?: string) {
     try {
-      const response = await fetch(`/api/jobs/outputs/${outputId}/download_url`);
+      const response = await apiFetch(`/api/jobs/outputs/${outputId}/download_url`);
       if (!response.ok) {
         const errorData = await response.json().catch(() => ({})); // Try to get error message
         let message = errorData.error || errorData.detail || `Failed to get download URL: ${response.statusText}`;

--- a/frontend/src/lib/components/Dashboard.svelte
+++ b/frontend/src/lib/components/Dashboard.svelte
@@ -2,6 +2,7 @@
   import { onMount, onDestroy, getContext } from 'svelte'; // Added getContext
   import GlassCard from './GlassCard.svelte';
   import Chart from 'chart.js/auto';
+  import { apiFetch } from '$lib/utils/apiUtils';
   export let orgId: string;
 
   const viewJobDetails = getContext<(jobId: string) => void>('viewJobDetails'); // Get context
@@ -26,14 +27,10 @@
   async function loadQuota() {
     if (!orgId) return;
     try {
-      const res = await fetch(`/api/dashboard/${orgId}`);
-      if (res.ok) {
-        const data = await res.json();
-        uploadRemaining = data.upload_remaining;
-        analysisRemaining = data.analysis_remaining;
-      } else {
-        console.error(`Failed to load quota data for org ${orgId}:`, await res.text());
-      }
+      const res = await apiFetch(`/api/dashboard/${orgId}`);
+      const data = await res.json();
+      uploadRemaining = data.upload_remaining;
+      analysisRemaining = data.analysis_remaining;
     } catch (error) {
       console.error(`Error loading quota data for org ${orgId}:`, error);
     }
@@ -42,9 +39,8 @@
   async function loadUsage() {
     if (!orgId || !canvasEl) return; // Ensure canvasEl is available
     try {
-      const usageRes = await fetch(`/api/dashboard/${orgId}/usage`);
-      if (usageRes.ok) {
-        const usage = await usageRes.json();
+      const usageRes = await apiFetch(`/api/dashboard/${orgId}/usage`);
+      const usage = await usageRes.json();
         const labels = usage.map((u: any) => u.month);
         const uploads = usage.map((u: any) => u.uploads);
         const analyses = usage.map((u: any) => u.analyses);
@@ -66,9 +62,6 @@
             scales: { x: { stacked: false }, y: { beginAtZero: true } }
           }
         });
-      } else {
-        console.error(`Failed to load usage data for org ${orgId}:`, await usageRes.text());
-      }
     } catch (error) {
       console.error(`Error loading usage data for org ${orgId}:`, error);
     }
@@ -77,12 +70,8 @@
   async function loadRecentAnalyses() {
     if (!orgId) return;
     try {
-      const res = await fetch(`/api/dashboard/${orgId}/recent_analyses`);
-      if (res.ok) {
-        recentAnalyses = await res.json();
-      } else {
-        console.error(`Failed to load recent analyses for org ${orgId}:`, await res.text());
-      }
+      const res = await apiFetch(`/api/dashboard/${orgId}/recent_analyses`);
+      recentAnalyses = await res.json();
     } catch (error) {
       console.error(`Error loading recent analyses for org ${orgId}:`, error);
     }

--- a/frontend/src/lib/components/DocumentList.svelte
+++ b/frontend/src/lib/components/DocumentList.svelte
@@ -4,6 +4,7 @@ import DataTable from './DataTable.svelte';
 import type { TableHeader } from './DataTable.svelte';
 import PaginationControls from './PaginationControls.svelte';
 import { onMount } from 'svelte';
+import { apiFetch } from '$lib/utils/apiUtils';
 import type { Document as APIDocument } from '$lib/types/api';
 
 // Base Document interface matching backend model
@@ -84,11 +85,7 @@ async function loadDocuments(pageToLoad = 1, newSortBy?: string | null, newSortO
     }
     // If filterType is 'all', is_target param is omitted.
 
-    const response = await fetch(apiUrl);
-    if (!response.ok) {
-      const errorText = await response.text(); // Or response.json().error if backend sends structured error
-      throw new Error(`Failed to load documents: ${response.status} ${errorText}`);
-    }
+    const response = await apiFetch(apiUrl);
     const data = await response.json();
 
     internalDocs = data.items.map((doc: Document): AppDocument => ({
@@ -173,13 +170,9 @@ function handleSortChange(event: CustomEvent<{ sortKey: string | null, sortDirec
 
 async function downloadDocument(id: string) {
   try {
-    const res = await fetch(`/api/download/${id}`, { credentials: 'include' });
-    if (res.ok) {
-      const { url } = await res.json();
-      window.open(url, '_blank');
-    } else {
-      alert('Failed to get download link: ' + await res.text());
-    }
+    const res = await apiFetch(`/api/download/${id}`);
+    const { url } = await res.json();
+    window.open(url, '_blank');
   } catch (error) {
     console.error("Download error:", error);
     alert('Error getting download link. See console.');

--- a/frontend/src/lib/components/UploadForm.svelte
+++ b/frontend/src/lib/components/UploadForm.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import { createEventDispatcher } from 'svelte';
+  import { apiFetch } from '$lib/utils/apiUtils';
 
   export let orgId: string;
   export let userId: string;
@@ -27,18 +28,14 @@
     }
 
     try {
-      const res = await fetch(`/api/upload?${params.toString()}`, {
+      await apiFetch(`/api/upload?${params.toString()}`, {
         method: 'POST',
         body: formData,
+        isFormData: true
       });
-      if (res.ok) {
-        dispatch('uploaded');
-        // Reset file input for next upload (optional, but good UX)
-        input.value = '';
-        isTarget = false; // Reset checkbox
-      } else {
-        alert('Upload failed: ' + (await res.text()));
-      }
+      dispatch('uploaded');
+      input.value = '';
+      isTarget = false;
     } catch (error) {
       console.error('Upload error:', error);
       alert('Upload failed. See console for details.');

--- a/frontend/src/lib/utils/sessionStore.ts
+++ b/frontend/src/lib/utils/sessionStore.ts
@@ -5,13 +5,15 @@ export interface SessionData {
   userId: string | null;
   org: string | null;
   role: string | null;
+  csrfToken: string | null;
 }
 
 const initial: SessionData = {
   loggedIn: false,
   userId: null,
   org: null,
-  role: null
+  role: null,
+  csrfToken: null
 };
 
 function createSessionStore() {

--- a/frontend/src/routes/+layout.ts
+++ b/frontend/src/routes/+layout.ts
@@ -1,5 +1,6 @@
 import type { LayoutLoad } from './$types';
 import { redirect } from '@sveltejs/kit';
+import { apiFetch } from '$lib/utils/apiUtils';
 
 export const load: LayoutLoad = async ({ fetch, url }) => {
   // If executed in browser and session is already populated by a previous run (e.g. from server on initial load),
@@ -12,13 +13,14 @@ export const load: LayoutLoad = async ({ fetch, url }) => {
   // console.log('Root +layout.ts load function executing. Browser:', browser);
 
   try {
-    const res = await fetch('/api/me');
+    const res = await apiFetch('/api/me', { fetchFn: fetch });
 
     let session = {
       loggedIn: false,
       userId: null as string | null,
       org: null as string | null,
-      role: null as string | null
+      role: null as string | null,
+      csrfToken: import.meta.env.VITE_CSRF_TOKEN ?? null
     };
 
     if (res.ok) {
@@ -27,7 +29,8 @@ export const load: LayoutLoad = async ({ fetch, url }) => {
         loggedIn: true,
         userId: userData.user_id,
         org: userData.org_id,
-        role: userData.role
+        role: userData.role,
+        csrfToken: import.meta.env.VITE_CSRF_TOKEN ?? null
       };
     }
 
@@ -53,7 +56,8 @@ export const load: LayoutLoad = async ({ fetch, url }) => {
         loggedIn: false,
         userId: null,
         org: null,
-        role: null
+        role: null,
+        csrfToken: import.meta.env.VITE_CSRF_TOKEN ?? null
       }
     };
   }

--- a/frontend/src/routes/login/+page.svelte
+++ b/frontend/src/routes/login/+page.svelte
@@ -12,28 +12,21 @@
   async function submit() {
     error = null;
     try {
-      const res = await apiFetch('/api/login', {
+      await apiFetch('/api/login', {
         method: 'POST',
         body: JSON.stringify({ email, password })
       });
-      if (res.ok) {
-        const me = await apiFetch('/api/me');
-        if (me.ok) {
-          const data = await me.json();
-          sessionStore.setSession({
-            loggedIn: true,
-            userId: data.user_id,
-            org: data.org_id,
-            role: data.role
-          });
-        } else {
-          sessionStore.setSession({ loggedIn: true, userId: null, org: null, role: null });
-        }
-        goto('/dashboard');
-      } else {
-        const data = await res.json().catch(() => ({ error: 'Login failed' }));
-        error = data.error || 'Login failed';
-      }
+
+      const me = await apiFetch('/api/me');
+      const data = await me.json();
+      sessionStore.setSession({
+        loggedIn: true,
+        userId: data.user_id,
+        org: data.org_id,
+        role: data.role,
+        csrfToken: import.meta.env.VITE_CSRF_TOKEN ?? null
+      });
+      goto('/dashboard');
     } catch (e: any) {
       error = e.message || 'Login failed';
     }


### PR DESCRIPTION
## Summary
- add global `apiFetch` wrapper that inserts CSRF header from `sessionStore`
- extend `sessionStore` with `csrfToken`
- store CSRF token after login and during layout load
- replace most `fetch` usages with new wrapper

## Testing
- `npm install` *(failed: vitest not found before install)*
- `npm test` *(fails: some component tests failing)*

------
https://chatgpt.com/codex/tasks/task_e_68698d22993c8333882609cb9610e26b