### PR TITLE
Add E2E tests script and CI step

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,6 +38,8 @@ jobs:
         run: cargo clippy --manifest-path backend/Cargo.toml --all-targets -- --deny warnings
       - name: Run migrations
         run: cargo run --manifest-path backend/Cargo.toml --bin migrate
+      - name: E2E Tests
+        run: ./scripts/run_tests_docker.sh
 
   frontend-coverage:
     needs: build

--- a/docs/Continuous_Integration.md
+++ b/docs/Continuous_Integration.md
@@ -10,6 +10,7 @@ A GitHub Actions workflow is provided at `.github/workflows/ci.yml`. On every pu
   - `npm run lint --prefix frontend`: Executes `svelte-check` (using the configuration in `frontend/tsconfig.json`) for type checking and other Svelte-specific diagnostics.
   - `npm test --prefix frontend`: Runs the frontend unit and component test suite using Vitest. Ensure `npm install --prefix frontend` has been run first so all dev dependencies are available.
   - `npm run build --prefix frontend`: Compiles the Svelte application to ensure the build process is successful.
+  - `./scripts/run_tests_docker.sh`: Starts PostgreSQL, Redis and MinIO using Docker Compose and then executes the backend and frontend tests. In the workflow this appears as the **E2E Tests** step.
 
 This CI pipeline helps maintain code quality and catch issues early in both the backend and frontend parts of the project.
 

--- a/scripts/run_tests_docker.sh
+++ b/scripts/run_tests_docker.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+set -e
+
+# Ensure running from repository root
+cd "$(dirname "$0")/.."
+
+# Start required services
+docker compose up -d db redis minio
+trap 'docker compose down' EXIT
+
+# Wait for Postgres to accept connections
+printf "Waiting for database to be ready"
+until docker compose exec -T db pg_isready -U postgres >/dev/null 2>&1; do
+  printf '.'
+  sleep 1
+done
+printf "\n"
+
+# Create test database if missing
+if ! docker compose exec -T db psql -U postgres -tAc "SELECT 1 FROM pg_database WHERE datname='testdb'" | grep -q 1; then
+  docker compose exec -T db psql -U postgres -c 'CREATE DATABASE testdb;'
+fi
+
+# Run backend and frontend tests
+cargo test --manifest-path backend/Cargo.toml --all-targets
+npm test --prefix frontend
+


### PR DESCRIPTION
## Summary
- add a `scripts/run_tests_docker.sh` helper that starts PostgreSQL, Redis and MinIO via Docker Compose and runs the test suites
- run that script in the CI workflow as the new `E2E Tests` step
- document the new step in **Continuous_Integration.md**

## Testing
- `./scripts/run_tests_docker.sh` *(fails: `docker` command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68699ecbe968833388b33288f2b53059