### PR TITLE
Add worker service install script

### DIFF
--- a/docs/Todo-fuer-User.md
+++ b/docs/Todo-fuer-User.md
@@ -6,17 +6,19 @@ Dieses Dokument beschreibt kurz, wie der Background-Worker als Dienst eingericht
    ```bash
    cargo build --release --bin worker --features worker-bin
    ```
-2. Dateien kopieren (Pfad bei Bedarf anpassen):
+2. Dienst automatisch installieren und starten:
+   ```bash
+   sudo ./scripts/install_worker_service.sh
+   ```
+   Der Service erwartet das Projekt unter `/opt/crPipeline`. Passe den Pfad in
+   der Unit-Datei an, falls es woanders liegt.
+
+   Alternativ kann die Installation manuell erfolgen:
    ```bash
    sudo mkdir -p /opt/crPipeline/scripts
    sudo cp scripts/worker_service.sh /opt/crPipeline/scripts/
    sudo cp deploy/worker.service /etc/systemd/system/worker.service
    sudo chmod +x /opt/crPipeline/scripts/worker_service.sh
-   ```
-   Der Service erwartet das Projekt unter `/opt/crPipeline`. Passe den Pfad in
-   der Unit-Datei an, falls es woanders liegt.
-3. Service aktivieren:
-   ```bash
    sudo systemctl daemon-reload
    sudo systemctl enable --now worker.service
    ```

--- a/scripts/install_worker_service.sh
+++ b/scripts/install_worker_service.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+# Install worker systemd service
+set -e
+
+# Run from repository root
+cd "$(dirname "$0")/.."
+
+TARGET=/opt/crPipeline
+UNIT_FILE=/etc/systemd/system/worker.service
+
+sudo mkdir -p "$TARGET/scripts"
+
+# Copy files for reference
+sudo cp deploy/worker.service "$TARGET/worker.service"
+sudo cp scripts/worker_service.sh "$TARGET/scripts/"
+
+sudo chmod +x "$TARGET/scripts/worker_service.sh"
+
+# Install systemd unit
+sudo cp deploy/worker.service "$UNIT_FILE"
+
+sudo systemctl daemon-reload
+sudo systemctl enable --now worker.service


### PR DESCRIPTION
## Summary
- provide install script for worker service
- document installation script usage

## Testing
- `npm test --prefix frontend` *(fails: vitest tests fail)*
- `cargo test --manifest-path backend/Cargo.toml` *(fails to build due to network limits)*

------
https://chatgpt.com/codex/tasks/task_e_68699ec944708333ab612405bf71c614