### PR TITLE
Enhance pipeline stage validation

### DIFF
--- a/backend/tests/pipeline_validation_tests.rs
+++ b/backend/tests/pipeline_validation_tests.rs
@@ -1,0 +1,29 @@
+use backend::pipeline_validation::validate_stages;
+use serde_json::json;
+
+#[test]
+fn valid_configurations() {
+    let stages = json!([
+        {"id": "a", "type": "ai", "command": "run_ai"},
+        {"id": "b", "type": "ocr", "command": "run_ocr", "ocr_engine": "external", "ocr_stage_endpoint": "http://ex", "ocr_stage_key": "k"},
+        {"id": "c", "type": "parse", "command": "run_parse"},
+        {"id": "d", "type": "report", "command": "run_report"}
+    ]);
+    assert!(validate_stages(&stages).is_ok());
+}
+
+#[test]
+fn missing_command_not_allowed() {
+    let stages = json!([
+        {"id": "a", "type": "ai"}
+    ]);
+    assert!(validate_stages(&stages).is_err());
+}
+
+#[test]
+fn ocr_key_without_external_engine_rejected() {
+    let stages = json!([
+        {"id": "b", "type": "ocr", "command": "run", "ocr_stage_key": "k"}
+    ]);
+    assert!(validate_stages(&stages).is_err());
+}


### PR DESCRIPTION
## Summary
- enforce presence of `command` for AI, OCR, Parse and Report stages
- ensure OCR stage key requires `ocr_engine="external"`
- adjust validation unit tests
- add new dedicated pipeline validation tests

## Testing
- `cargo test --manifest-path backend/Cargo.toml` *(fails: PoolTimedOut)*

------
https://chatgpt.com/codex/tasks/task_e_68699ec7807483338f10661d1003a987