### PR TITLE
Add pipeline CRUD integration tests

### DIFF
--- a/backend/tests/pipeline_crud_integration.rs
+++ b/backend/tests/pipeline_crud_integration.rs
@@ -1,0 +1,119 @@
+use actix_web::{test, http::header};
+use uuid::Uuid;
+use serde_json::json;
+
+mod test_utils;
+use test_utils::{
+    setup_test_app, create_org, create_user, generate_jwt_token, clear_database,
+};
+
+#[actix_rt::test]
+async fn test_create_pipeline_integration() {
+    let Ok((app, pool)) = setup_test_app().await else { return; };
+    let org_id = create_org(&pool, "Crud Org").await;
+    let user_id = create_user(&pool, org_id, "create@example.com", "org_admin").await;
+    let token = generate_jwt_token(user_id, org_id, "org_admin");
+
+    let payload = json!({
+        "org_id": org_id,
+        "name": "CreatePipe",
+        "stages": [{"type": "ocr", "command": "echo hi"}]
+    });
+    let req = test::TestRequest::post()
+        .uri("/api/pipelines")
+        .insert_header((header::AUTHORIZATION, format!("Bearer {}", token)))
+        .set_json(&payload)
+        .to_request();
+    let resp = test::call_service(&app, req).await;
+    assert!(resp.status().is_success());
+    let created: serde_json::Value = test::read_body_json(resp).await;
+    let pipeline_id = created["id"].as_str().unwrap();
+
+    let count: (i64,) = sqlx::query_as("SELECT COUNT(*) FROM pipelines WHERE id=$1")
+        .bind(Uuid::parse_str(pipeline_id).unwrap())
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+    assert_eq!(count.0, 1);
+
+    clear_database(&pool).await;
+}
+
+#[actix_rt::test]
+async fn test_update_pipeline_integration() {
+    let Ok((app, pool)) = setup_test_app().await else { return; };
+    let org_id = create_org(&pool, "Crud Org2").await;
+    let user_id = create_user(&pool, org_id, "update@example.com", "org_admin").await;
+    let token = generate_jwt_token(user_id, org_id, "org_admin");
+
+    let payload = json!({
+        "org_id": org_id,
+        "name": "PipeToUpdate",
+        "stages": [{"type": "ocr", "command": "echo hi"}]
+    });
+    let req = test::TestRequest::post()
+        .uri("/api/pipelines")
+        .insert_header((header::AUTHORIZATION, format!("Bearer {}", token)))
+        .set_json(&payload)
+        .to_request();
+    let resp = test::call_service(&app, req).await;
+    assert!(resp.status().is_success());
+    let created: serde_json::Value = test::read_body_json(resp).await;
+    let pipeline_id = created["id"].as_str().unwrap();
+
+    let update_payload = json!({
+        "org_id": org_id,
+        "name": "PipeUpdated",
+        "stages": [{"type": "ocr", "command": "echo hi"}]
+    });
+    let req = test::TestRequest::put()
+        .uri(&format!("/api/pipelines/{}", pipeline_id))
+        .insert_header((header::AUTHORIZATION, format!("Bearer {}", token)))
+        .set_json(&update_payload)
+        .to_request();
+    let resp = test::call_service(&app, req).await;
+    assert!(resp.status().is_success());
+    let updated: serde_json::Value = test::read_body_json(resp).await;
+    assert_eq!(updated["name"], "PipeUpdated");
+
+    clear_database(&pool).await;
+}
+
+#[actix_rt::test]
+async fn test_delete_pipeline_integration() {
+    let Ok((app, pool)) = setup_test_app().await else { return; };
+    let org_id = create_org(&pool, "Crud Org3").await;
+    let user_id = create_user(&pool, org_id, "delete@example.com", "org_admin").await;
+    let token = generate_jwt_token(user_id, org_id, "org_admin");
+
+    let payload = json!({
+        "org_id": org_id,
+        "name": "PipeToDelete",
+        "stages": [{"type": "ocr", "command": "echo hi"}]
+    });
+    let req = test::TestRequest::post()
+        .uri("/api/pipelines")
+        .insert_header((header::AUTHORIZATION, format!("Bearer {}", token)))
+        .set_json(&payload)
+        .to_request();
+    let resp = test::call_service(&app, req).await;
+    assert!(resp.status().is_success());
+    let created: serde_json::Value = test::read_body_json(resp).await;
+    let pipeline_id = created["id"].as_str().unwrap();
+
+    let req = test::TestRequest::delete()
+        .uri(&format!("/api/pipelines/{}", pipeline_id))
+        .insert_header((header::AUTHORIZATION, format!("Bearer {}", token)))
+        .to_request();
+    let resp = test::call_service(&app, req).await;
+    assert!(resp.status().is_success());
+    let count: (i64,) = sqlx::query_as("SELECT COUNT(*) FROM pipelines WHERE id=$1")
+        .bind(Uuid::parse_str(pipeline_id).unwrap())
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+    assert_eq!(count.0, 0);
+
+    clear_database(&pool).await;
+}
+

--- a/backend/tests/pipeline_validation_tests.rs
+++ b/backend/tests/pipeline_validation_tests.rs
@@ -27,3 +27,35 @@ fn ocr_key_without_external_engine_rejected() {
     ]);
     assert!(validate_stages(&stages).is_err());
 }
+
+#[test]
+fn invalid_ocr_engine_rejected() {
+    let stages = json!([
+        {"type": "ocr", "command": "run", "ocr_engine": "foo"}
+    ]);
+    assert!(validate_stages(&stages).is_err());
+}
+
+#[test]
+fn external_ocr_without_endpoint_rejected() {
+    let stages = json!([
+        {"type": "ocr", "command": "run", "ocr_engine": "external"}
+    ]);
+    assert!(validate_stages(&stages).is_err());
+}
+
+#[test]
+fn external_ocr_with_empty_endpoint_rejected() {
+    let stages = json!([
+        {"type": "ocr", "command": "run", "ocr_engine": "external", "ocr_stage_endpoint": ""}
+    ]);
+    assert!(validate_stages(&stages).is_err());
+}
+
+#[test]
+fn external_ocr_with_non_string_key_rejected() {
+    let stages = json!([
+        {"type": "ocr", "command": "run", "ocr_engine": "external", "ocr_stage_endpoint": "http://ex", "ocr_stage_key": 5}
+    ]);
+    assert!(validate_stages(&stages).is_err());
+}

--- a/backend/tests/test_utils.rs
+++ b/backend/tests/test_utils.rs
@@ -95,3 +95,12 @@ pub async fn create_unconfirmed_user(pool: &PgPool, org_id: Uuid, email: &str, r
         .unwrap();
     user_id
 }
+
+pub async fn clear_database(pool: &PgPool) {
+    sqlx::query(
+        "TRUNCATE TABLE job_stage_outputs, analysis_jobs, pipelines, documents, audit_logs, users, org_settings, organizations RESTART IDENTITY CASCADE"
+    )
+    .execute(pool)
+    .await
+    .unwrap();
+}


### PR DESCRIPTION
## Summary
- add new pipeline CRUD integration test suite
- extend pipeline stage validation tests for OCR options
- provide utility to clear the test database after tests

## Testing
- `cargo test --quiet` *(fails: Failed to connect to test database)*

------
https://chatgpt.com/codex/tasks/task_e_6869b384714c8333914e0b0fc9f77e86