### PR TITLE
Add DaisyUI build step

### DIFF
--- a/docs/Todo-fuer-User.md
+++ b/docs/Todo-fuer-User.md
@@ -51,3 +51,16 @@ sudo chmod +x /opt/crPipeline/scripts/worker_service.sh
 sudo systemctl daemon-reload
 sudo systemctl enable --now worker.service
 ```
+
+## Statische Assets ausliefern
+
+Um die gebaute Weboberfläche im Produktivbetrieb bereitzustellen, sollten die Dateien aus
+`frontend/dist` von einem Webserver wie nginx ausgeliefert werden. Baue das
+Frontend zuvor mit dem DaisyUI-Schritt:
+
+```bash
+npm run build:prod --prefix frontend
+```
+
+Kopiere danach den Inhalt von `frontend/dist` an den Ort, den dein Webserver
+als Dokumentenwurzel nutzt oder binde das Verzeichnis als Volume ein.

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -8,7 +8,7 @@ FROM node:20 AS build
 WORKDIR /app
 COPY --from=deps /app/node_modules ./node_modules
 COPY frontend .
-RUN npm run build
+RUN npm run build:prod
 
 FROM nginx:alpine
 COPY --from=build /app/dist /usr/share/nginx/html

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -17,6 +17,7 @@
         "@testing-library/user-event": "^14.6.1",
         "@vitest/coverage-v8": "^0.34.6",
         "autoprefixer": "^10.4.14",
+        "daisyui": "^5.0.43",
         "jsdom": "^22.1.0",
         "postcss": "^8.4.24",
         "svelte": "^4.2.0",
@@ -1667,6 +1668,16 @@
       },
       "engines": {
         "node": ">=14"
+      }
+    },
+    "node_modules/daisyui": {
+      "version": "5.0.43",
+      "resolved": "https://registry.npmjs.org/daisyui/-/daisyui-5.0.43.tgz",
+      "integrity": "sha512-2pshHJ73vetSpsbAyaOncGnNYL0mwvgseS1EWy1I9Qpw8D11OuBoDNIWrPIME4UFcq2xuff3A9x+eXbuFR9fUQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/saadeghi/daisyui?sponsor=1"
       }
     },
     "node_modules/data-urls": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -5,6 +5,8 @@
   "scripts": {
     "dev": "vite",
     "build": "vite build",
+    "build:themes": "tailwindcss -c tailwind.config.cjs -i ./src/app.css -o ./src/generated-themes.css --minify",
+    "build:prod": "npm run build:themes && vite build",
     "preview": "vite preview",
     "test": "vitest",
     "lint": "svelte-check --tsconfig ./tsconfig.json"
@@ -22,6 +24,7 @@
     "svelte-check": "^3.6.2",
     "svelte-preprocess": "^5.0.4",
     "tailwindcss": "^3.3.2",
+    "daisyui": "^5.0.43",
     "typescript": "^5.1.3",
     "vite": "^4.3.9",
     "vitest": "^0.34.6"

--- a/frontend/tailwind.config.cjs
+++ b/frontend/tailwind.config.cjs
@@ -29,5 +29,5 @@ module.exports = {
       },
     }
   },
-  plugins: [],
+  plugins: [require('daisyui')],
 };


### PR DESCRIPTION
## Summary
- generate DaisyUI themes via Tailwind CLI
- hook DaisyUI build step into Dockerfile
- document how to serve static assets in production

## Testing
- `npm test --prefix frontend` *(fails: <DataTable> unknown prop)*

------
https://chatgpt.com/codex/tasks/task_e_6869b384a0b0833395e3ac9647a82944