### PR TITLE
Add frontend Playwright E2E tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,7 +39,10 @@ jobs:
       - name: Run migrations
         run: cargo run --manifest-path backend/Cargo.toml --bin migrate
       - name: E2E Tests
-        run: ./scripts/run_tests_docker.sh
+        run: |
+          ./scripts/run_tests_docker.sh
+          npx playwright install --with-deps
+          npm run e2e --prefix frontend
 
   frontend-coverage:
     needs: build

--- a/frontend/e2e/login.e2e.ts
+++ b/frontend/e2e/login.e2e.ts
@@ -1,0 +1,13 @@
+import { test, expect } from '@playwright/test';
+
+test('login success', async ({ page }) => {
+  await page.route('**/api/login', route => route.fulfill({ status: 200, body: '{"success":true}' }));
+  await page.route('**/api/me', route => route.fulfill({ status: 200, body: JSON.stringify({ user_id: '1', org_id: '1', role: 'admin' }) }));
+
+  await page.goto('/login');
+  await page.fill('input[type=email]', 'user@example.com');
+  await page.fill('input[type=password]', 'password');
+  await page.click('button[type=submit]');
+  await page.waitForURL('/dashboard');
+  await expect(page).toHaveURL(/dashboard/);
+});

--- a/frontend/e2e/upload.e2e.ts
+++ b/frontend/e2e/upload.e2e.ts
@@ -1,0 +1,14 @@
+import { test, expect } from '@playwright/test';
+import fs from 'fs';
+
+test('file upload', async ({ page }, testInfo) => {
+  await page.route('**/api/upload**', route => route.fulfill({ status: 200, body: '{}' }));
+  await page.route('**/api/me', route => route.fulfill({ status: 200, body: JSON.stringify({ user_id: '1', org_id: '1', role: 'admin' }) }));
+
+  await page.goto('/dashboard');
+
+  const filePath = testInfo.outputPath('sample.txt');
+  fs.writeFileSync(filePath, 'hello');
+  await page.setInputFiles('input[type=file]', filePath);
+  await expect(page.locator('input[type=file]')).toHaveValue('');
+});

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -11,6 +11,7 @@
         "chart.js": "^4.3.0"
       },
       "devDependencies": {
+        "@playwright/test": "^1.39.0",
         "@sveltejs/vite-plugin-svelte": "^2.0.0",
         "@testing-library/jest-dom": "^6.0.0",
         "@testing-library/svelte": "^4.0.0",
@@ -626,6 +627,22 @@
       "optional": true,
       "engines": {
         "node": ">=14"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.53.2",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.53.2.tgz",
+      "integrity": "sha512-tEB2U5z74ebBeyfGNZ3Jfg29AnW+5HlWhvHtb/Mqco9pFdZU1ZLNdVb2UtB5CvmiilNr2ZfVH/qMmAROG/XTzw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.53.2"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@sinclair/typebox": {
@@ -3572,6 +3589,53 @@
       "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/playwright": {
+      "version": "1.53.2",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.53.2.tgz",
+      "integrity": "sha512-6K/qQxVFuVQhRQhFsVZ9fGeatxirtrpPgxzBYWyZLEXJzqYwuL4fuNmfOfD5et1tJE4GScKyPNeLhZeRwuTU3A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.53.2"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.53.2",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.53.2.tgz",
+      "integrity": "sha512-ox/OytMy+2w1jcYEYlOo1Hhp8hZkLCximMTUTMBXjGUA1KoFfiSZ+DU+3a739jsPY0yoKH2TFy9S2fsJas8yAw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
     },
     "node_modules/possible-typed-array-names": {
       "version": "1.1.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -9,7 +9,8 @@
     "build:prod": "npm run build:themes && vite build",
     "preview": "vite preview",
     "test": "vitest",
-    "lint": "svelte-check --tsconfig ./tsconfig.json"
+    "lint": "svelte-check --tsconfig ./tsconfig.json",
+    "e2e": "playwright test"
   },
   "devDependencies": {
     "@sveltejs/vite-plugin-svelte": "^2.0.0",
@@ -27,7 +28,8 @@
     "daisyui": "^5.0.43",
     "typescript": "^5.1.3",
     "vite": "^4.3.9",
-    "vitest": "^0.34.6"
+    "vitest": "^0.34.6",
+    "@playwright/test": "^1.39.0"
   },
   "dependencies": {
     "chart.js": "^4.3.0"

--- a/frontend/playwright.config.ts
+++ b/frontend/playwright.config.ts
@@ -1,0 +1,15 @@
+import { defineConfig } from '@playwright/test';
+
+export default defineConfig({
+  testDir: './e2e',
+  testMatch: /.*\.e2e\.ts/,
+  webServer: {
+    command: 'npm run preview -- --port=4173',
+    port: 4173,
+    reuseExistingServer: !process.env.CI,
+  },
+  use: {
+    baseURL: 'http://localhost:4173',
+    headless: true,
+  },
+});

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -15,7 +15,8 @@
     ],
     "types": [
       "svelte",
-      "vitest/globals"
+      "vitest/globals",
+      "@playwright/test"
     ],
     "allowSyntheticDefaultImports": true,
     "baseUrl": ".",


### PR DESCRIPTION
## Summary
- add Playwright test runner and scripts
- create sample login and upload E2E tests
- configure Playwright
- run E2E tests in CI

## Testing
- `npm test --prefix frontend` *(fails: DocumentList events)*
- `npm run lint --prefix frontend` *(fails: svelte-check errors)*
- `npx playwright test --config frontend/playwright.config.ts` *(fails: npm error canceled)*
- `cargo test --manifest-path backend/Cargo.toml --all-targets` *(fails: interrupted)*

------
https://chatgpt.com/codex/tasks/task_e_686a531519488333ae2fd8fd666e9a6b