### PR TITLE
Adopt DaisyUI styling

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 Multi-tenant document analysis platform built with Rust and Svelte.
 
+The frontend uses [DaisyUI](https://daisyui.com) components with the `corporate` and `business` themes. See [docs/DaisyUI_Themes.md](docs/DaisyUI_Themes.md) for details.
+
 ## Documentation
 - [Usage](docs/Usage.md)
 - [Architecture](docs/Architecture.md)

--- a/docs/DaisyUI_Themes.md
+++ b/docs/DaisyUI_Themes.md
@@ -1,0 +1,8 @@
+# DaisyUI Themes
+
+The frontend is styled with [DaisyUI](https://daisyui.com/). Two themes are enabled:
+
+- `corporate` – used as the default light mode.
+- `business` – used for dark mode.
+
+When you build the frontend, Tailwind will generate the CSS for these themes automatically. Switch themes by setting `data-theme` on the `html` element at runtime.

--- a/frontend/src/lib/components/Button.svelte
+++ b/frontend/src/lib/components/Button.svelte
@@ -2,48 +2,21 @@
   export let variant: 'primary' | 'secondary' | 'ghost' = 'primary';
   export let type: 'button' | 'submit' | 'reset' = 'button';
   export let disabled: boolean = false;
-  export let customClass: string = ''; // Renamed from 'class' to avoid conflict if used directly
+  export let customClass: string = '';
   export let href: string | undefined = undefined;
 
-  let baseClasses: string =
-    "px-4 py-2 rounded-lg font-semibold focus:outline-none focus:ring-2 focus:ring-offset-2 \
-    transition-colors duration-150 ease-in-out inline-flex items-center justify-center \
-    disabled:cursor-not-allowed"; // Common disabled behavior
-
-  let currentVariantClasses: string = '';
-
-  // Reactive statement to update classes based on variant and disabled state
-  $: {
-    switch (variant) {
-      case 'primary':
-        currentVariantClasses = `
-          bg-accent text-white
-          hover:bg-accent/80
-          focus:ring-accent
-          disabled:bg-gray-300 disabled:text-gray-500`;
-        break;
-      case 'secondary':
-        currentVariantClasses = `
-          bg-white/70 backdrop-blur-sm text-accent border border-accent/50
-          hover:bg-white/90 hover:border-accent
-          focus:ring-accent
-          disabled:bg-gray-200/50 disabled:text-gray-400 disabled:border-gray-300/50`;
-        break;
-      case 'ghost':
-        currentVariantClasses = `
-          bg-transparent text-accent
-          hover:bg-accent/10
-          focus:ring-accent focus:bg-accent/10
-          disabled:text-gray-400`;
-        break;
-    }
-  }
+  $: variantClass =
+    variant === 'primary'
+      ? 'btn-primary'
+      : variant === 'secondary'
+      ? 'btn-secondary'
+      : 'btn-ghost';
 </script>
 
 {#if href}
   <a
     href={href}
-    class="{baseClasses} {currentVariantClasses} {customClass}"
+    class="btn {variantClass} {customClass}"
     aria-disabled={disabled}
     on:click
   >
@@ -52,7 +25,7 @@
 {:else}
   <button
     type={type}
-    class="{baseClasses} {currentVariantClasses} {customClass}"
+    class="btn {variantClass} {customClass}"
     {disabled}
     on:click
   >
@@ -60,15 +33,3 @@
   </button>
 {/if}
 
-<style lang="postcss">
-  /* Ensure --color-accent is available globally for bg-accent to work */
-  /* e.g., in your app.css or global style block: */
-  /* :root { --color-accent: #30D5C8; } */
-  /* Tailwind JIT should pick up bg-accent if --color-accent is defined in a way it understands,
-     or if 'accent' is configured as a color in tailwind.config.js */
-
-  /* Opacity modifiers like /80, /10 for bg-accent assume that 'accent' is a color
-     that Tailwind can apply alpha to (e.g. using CSS variables with R,G,B components or a hex code).
-     If --color-accent is just a hex string, Tailwind CSS v3+ usually handles this.
-   */
-</style>

--- a/frontend/src/lib/components/LoginForm.svelte
+++ b/frontend/src/lib/components/LoginForm.svelte
@@ -22,9 +22,9 @@
 </script>
 
 <form class="space-y-4" on:submit|preventDefault={submit}>
-  <input class="glass-input w-full" type="email" bind:value={email} placeholder="Email" required />
-  <input class="glass-input w-full" type="password" bind:value={password} placeholder="Password" required />
-  <button class="btn-primary w-full" on:click|preventDefault={submit}>Login</button>
+  <input class="input input-bordered glass w-full" type="email" bind:value={email} placeholder="Email" required />
+  <input class="input input-bordered glass w-full" type="password" bind:value={password} placeholder="Password" required />
+  <button class="btn btn-primary w-full" on:click|preventDefault={submit}>Login</button>
   {#if error}
     <p class="text-red-500 text-sm">{error}</p>
   {/if}

--- a/frontend/src/lib/components/UploadForm.svelte
+++ b/frontend/src/lib/components/UploadForm.svelte
@@ -49,7 +49,7 @@
 <div class="space-y-3 p-1">
   <div>
     <input
-      class="glass-input w-full text-sm file:mr-4 file:py-2 file:px-4 file:rounded-full file:border-0 file:text-sm file:font-semibold file:bg-accent/20 file:text-accent hover:file:bg-accent/30"
+      class="file-input file-input-bordered glass w-full text-sm"
       type="file"
       accept="application/pdf,.md,.txt"
       on:change={handleUpload}

--- a/frontend/src/lib/components/pipeline_editor/StageList.svelte
+++ b/frontend/src/lib/components/pipeline_editor/StageList.svelte
@@ -158,12 +158,12 @@
     >
       <div class="flex items-center gap-2 mb-2">
         <input
-          class="glass-input flex-1 !bg-neutral-600/50 !border-neutral-500/70 !text-gray-100"
+          class="input input-bordered glass flex-1 !bg-neutral-600/50 !border-neutral-500/70 !text-gray-100"
           bind:value={stage.type}
           placeholder="Stage Type (e.g., ocr, ai)"
         />
         <input
-          class="glass-input flex-1 !bg-neutral-600/50 !border-neutral-500/70 !text-gray-100"
+          class="input input-bordered glass flex-1 !bg-neutral-600/50 !border-neutral-500/70 !text-gray-100"
           bind:value={stage.command}
           placeholder="Command / Config (optional)"
         />

--- a/frontend/tailwind.config.cjs
+++ b/frontend/tailwind.config.cjs
@@ -30,4 +30,7 @@ module.exports = {
     }
   },
   plugins: [require('daisyui')],
+  daisyui: {
+    themes: ['corporate', 'business']
+  }
 };


### PR DESCRIPTION
## Summary
- switch Button component to DaisyUI `btn`
- use DaisyUI classes in LoginForm and UploadForm
- use DaisyUI inputs in StageList
- enable `corporate` and `business` themes in tailwind config
- document DaisyUI theme usage

## Testing
- `npm test --prefix frontend` *(fails: vitest errors)*

------
https://chatgpt.com/codex/tasks/task_e_686a531424fc83339f3ae66610b35c9d