### PR TITLE
Update docs for new worker options

### DIFF
--- a/docs/Changelog.md
+++ b/docs/Changelog.md
@@ -2,6 +2,11 @@
 
 All notable changes to this project will be documented in this file.
 
+## v0.4 - 2025-07-06
+- Added concurrent job processing via `WORKER_CONCURRENCY`.
+- Frontend build now precompiles DaisyUI themes.
+- Added pipeline CRUD integration tests.
+
 ## v0.3 - 2025-07-05
 - Added settings page and global API fetch wrapper.
 - Implemented document deletion and worker service script.

--- a/docs/Deployment.md
+++ b/docs/Deployment.md
@@ -134,6 +134,9 @@ Die Images werden normalerweise durch den CI-Workflow erstellt. Bei Bedarf könn
 docker build -t myorg/backend:latest backend
 docker build -t myorg/frontend:latest frontend
 ```
+The frontend Dockerfile runs `npm run build:prod` so DaisyUI themes are included
+in the production build. If you build the frontend without Docker, run this
+command manually before copying `frontend/dist`.
 
 ### Kubernetes-Manifeste nutzen
 Alle notwendigen Ressourcen befinden sich im Verzeichnis `k8s/`. Mit

--- a/docs/Setup.md
+++ b/docs/Setup.md
@@ -29,6 +29,8 @@
 
 Environment variables can be tweaked in `backend/.env` to point to a different database or S3 endpoint. Ensure the bucket defined in `S3_BUCKET` exists in your MinIO or AWS account.
 `PROCESS_ONE_JOB` makes the worker exit after a single job. Setting `LOCAL_S3_DIR` lets the worker store uploaded files under that path instead of S3, handy for local tests.
+`WORKER_CONCURRENCY` controls how many jobs a single worker processes in parallel.
+`SHUTDOWN_AFTER_IDLE` shuts the worker down after the given minutes of inactivity.
 
 The backend optionally supports an external OCR service. Set `OCR_API_ENDPOINT` and `OCR_API_KEY` in `backend/.env` to provide a global endpoint and API key used when no organization or stage-specific OCR configuration is present.
 
@@ -41,6 +43,13 @@ docker compose up --build
 
 This launches Postgres, MinIO, Redis, the backend API and the compiled frontend. The
 application will be available on the same ports as above.
+
+When preparing a production build, generate the DaisyUI themes before the regular
+Vite build:
+
+```bash
+npm run build:prod --prefix frontend
+```
 
 After the first migration you can seed an admin user (role `admin`) with the following command:
 ```bash

--- a/docs/Usage.md
+++ b/docs/Usage.md
@@ -17,7 +17,7 @@ cargo run --bin migrate
 
 ## Testing
 - `cargo test` – backend unit tests
-- `npm run build --prefix frontend` – ensure Svelte app compiles
+- `npm run build:prod --prefix frontend` – ensure Svelte app compiles and DaisyUI themes are generated
 - `npm install --prefix frontend` – install dev dependencies before running frontend tests
 - `npm test --prefix frontend` – run frontend unit and component tests
 
@@ -39,14 +39,17 @@ cargo run --bin worker --features worker-bin
 ```
 
 In production compile and run the worker binary in release mode. Set
-`REDIS_URL` to the Redis instance used by the API. Optionally set
-`PROCESS_ONE_JOB=1` so the worker exits after a single job which is useful in
-container pre-stop hooks. Start multiple workers for higher throughput:
+`REDIS_URL` to the Redis instance used by the API. `WORKER_CONCURRENCY`
+specifies how many jobs a single worker processes in parallel. Optionally use
+`SHUTDOWN_AFTER_IDLE` to exit after a period of inactivity or
+`PROCESS_ONE_JOB=1` for pre-stop hooks. Multiple worker processes can be started
+if desired:
 ```bash
 cargo build --release --bin worker --features worker-bin
 REDIS_URL=redis://redis:6379/ ./target/release/worker
 ```
-Running the command in several processes allows jobs to be handled concurrently.
+Running multiple worker processes or increasing `WORKER_CONCURRENCY` allows jobs
+to be handled concurrently.
 
 ## Cleanup
 Remove expired documents that have passed their `expires_at` timestamp.
@@ -90,7 +93,7 @@ Add AI prompt templates to organization settings using the following structure:
 Compile the backend and build the frontend:
 ```bash
 cargo build --release --manifest-path backend/Cargo.toml
-npm run build --prefix frontend
+npm run build:prod --prefix frontend
 ```
 Serve `frontend/dist` with a static server and run the compiled backend binary with the appropriate environment.
 


### PR DESCRIPTION
## Summary
- document worker concurrency and idle shutdown variables
- describe DaisyUI build step in Setup, Usage and Deployment docs
- note new concurrent job processing release in Changelog

## Testing
- `scripts/run_tests_docker.sh` *(fails: `docker` not found)*
- `npm run build:prod --prefix frontend` *(fails: `tailwindcss` not found)*

------
https://chatgpt.com/codex/tasks/task_e_686a5316b960833381fc53d35891c0fd