### PR TITLE
Add Playwright E2E setup

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,9 +38,12 @@ jobs:
         run: cargo clippy --manifest-path backend/Cargo.toml --all-targets -- --deny warnings
       - name: Run migrations
         run: cargo run --manifest-path backend/Cargo.toml --bin migrate
-      - name: E2E Tests
+      - name: Unit Tests
+        run: ./scripts/run_tests_docker.sh
+      - name: Seed demo data
+        run: ./scripts/seed_demo.sh
+      - name: Playwright E2E
         run: |
-          ./scripts/run_tests_docker.sh
           npx playwright install --with-deps
           npm run e2e --prefix frontend
 

--- a/docs/Continuous_Integration.md
+++ b/docs/Continuous_Integration.md
@@ -30,3 +30,14 @@ login succeeds for confirmed users and fails for unconfirmed accounts. Start the
 database services via `docker compose up -d db redis minio` and run `cargo test`
 to execute the full suite.
 
+### End-to-End Tests
+Playwright tests live in `frontend/e2e`. When running locally, the test runner
+builds and starts all containers from `docker-compose.yml` and seeds demo data
+with `scripts/seed_demo.sh`. Execute the suite with:
+
+```bash
+npm run e2e --prefix frontend
+```
+
+The CI workflow performs the same steps after the unit tests finish.
+

--- a/frontend/e2e/global-setup.ts
+++ b/frontend/e2e/global-setup.ts
@@ -1,0 +1,33 @@
+import { FullConfig } from '@playwright/test';
+import { execSync } from 'child_process';
+import http from 'http';
+import path from 'path';
+
+async function waitFor(url: string, timeout = 60000) {
+  const start = Date.now();
+  while (Date.now() - start < timeout) {
+    try {
+      await new Promise<void>((resolve, reject) => {
+        const req = http.get(url, res => { res.resume(); resolve(); });
+        req.on('error', reject);
+      });
+      return;
+    } catch {
+      await new Promise(res => setTimeout(res, 1000));
+    }
+  }
+  throw new Error(`Timed out waiting for ${url}`);
+}
+
+export default async function globalSetup(config: FullConfig) {
+  const root = path.join(__dirname, '..', '..');
+  execSync('docker compose up -d', { cwd: root, stdio: 'inherit' });
+  try {
+    await waitFor('http://localhost:5173');
+    await waitFor('http://localhost:8080/health');
+    execSync('./scripts/seed_demo.sh', { cwd: root, stdio: 'inherit' });
+  } catch (err) {
+    execSync('docker compose down', { cwd: root, stdio: 'inherit' });
+    throw err;
+  }
+}

--- a/frontend/e2e/global-teardown.ts
+++ b/frontend/e2e/global-teardown.ts
@@ -1,0 +1,7 @@
+import { execSync } from 'child_process';
+import path from 'path';
+
+export default async function globalTeardown() {
+  const root = path.join(__dirname, '..', '..');
+  execSync('docker compose down', { cwd: root, stdio: 'inherit' });
+}

--- a/frontend/e2e/job_status.e2e.ts
+++ b/frontend/e2e/job_status.e2e.ts
@@ -1,0 +1,13 @@
+import { test, expect } from '@playwright/test';
+
+// Checks that recent job status is displayed
+
+test('job status visible on dashboard', async ({ page }) => {
+  await page.goto('/login');
+  await page.fill('input[type=email]', 'demo@example.com');
+  await page.fill('input[type=password]', 'password');
+  await page.click('button[type=submit]');
+  await page.waitForURL('/dashboard');
+
+  await expect(page.locator('text=Status')).toBeVisible();
+});

--- a/frontend/e2e/login_flow.e2e.ts
+++ b/frontend/e2e/login_flow.e2e.ts
@@ -1,0 +1,12 @@
+import { test, expect } from '@playwright/test';
+
+// Full login against running backend seeded via scripts/seed_demo.sh
+
+test('user can log in via UI', async ({ page }) => {
+  await page.goto('/login');
+  await page.fill('input[type=email]', 'demo@example.com');
+  await page.fill('input[type=password]', 'password');
+  await page.click('button[type=submit]');
+  await page.waitForURL('/dashboard');
+  await expect(page).toHaveURL(/dashboard/);
+});

--- a/frontend/e2e/pipeline_create.e2e.ts
+++ b/frontend/e2e/pipeline_create.e2e.ts
@@ -1,0 +1,22 @@
+import { test, expect } from '@playwright/test';
+
+// Creates a simple pipeline via UI
+
+test('create pipeline', async ({ page }) => {
+  // login first
+  await page.goto('/login');
+  await page.fill('input[type=email]', 'demo@example.com');
+  await page.fill('input[type=password]', 'password');
+  await page.click('button[type=submit]');
+  await page.waitForURL('/dashboard');
+
+  await page.goto('/pipelines');
+  await page.click('text=Create New Pipeline');
+  await page.fill('input[placeholder="Pipeline name"]', 'Test Pipeline');
+  await page.fill('input[placeholder="New Stage Type"]', 'parse');
+  await page.click('text=Add Stage');
+
+  // accept alert on save
+  page.once('dialog', dialog => dialog.accept());
+  await page.click('text=Save');
+});

--- a/frontend/e2e/upload_flow.e2e.ts
+++ b/frontend/e2e/upload_flow.e2e.ts
@@ -1,0 +1,19 @@
+import { test, expect } from '@playwright/test';
+import fs from 'fs';
+
+// Login and upload a small text file
+
+test('document upload works', async ({ page }, testInfo) => {
+  await page.goto('/login');
+  await page.fill('input[type=email]', 'demo@example.com');
+  await page.fill('input[type=password]', 'password');
+  await page.click('button[type=submit]');
+  await page.waitForURL('/dashboard');
+
+  const filePath = testInfo.outputPath('sample.txt');
+  fs.writeFileSync(filePath, 'hello');
+  const fileInput = page.locator('input[type=file]');
+  await fileInput.setInputFiles(filePath);
+  // After upload input should be cleared
+  await expect(fileInput).toHaveValue('');
+});

--- a/frontend/playwright.config.ts
+++ b/frontend/playwright.config.ts
@@ -1,15 +1,13 @@
 import { defineConfig } from '@playwright/test';
+import path from 'path';
 
 export default defineConfig({
   testDir: './e2e',
   testMatch: /.*\.e2e\.ts/,
-  webServer: {
-    command: 'npm run preview -- --port=4173',
-    port: 4173,
-    reuseExistingServer: !process.env.CI,
-  },
+  globalSetup: path.join(__dirname, 'e2e/global-setup.ts'),
+  globalTeardown: path.join(__dirname, 'e2e/global-teardown.ts'),
   use: {
-    baseURL: 'http://localhost:4173',
+    baseURL: 'http://localhost:5173',
     headless: true,
   },
 });


### PR DESCRIPTION
## Summary
- add Playwright global setup/teardown to start docker compose and seed demo
- create login, upload, pipeline and job status E2E tests
- adjust Playwright config for docker based runs
- extend CI workflow to seed data and run Playwright after unit tests
- document how to run the E2E suite

## Testing
- `./scripts/run_tests_docker.sh` *(fails: `docker: command not found`)*
- `npm test --prefix frontend` *(fails: some tests failed)*
- `npx playwright test --config frontend/playwright.config.ts` *(fails: awaiting package install)*

------
https://chatgpt.com/codex/tasks/task_e_686a66c62af88333a82d51023f05200a