### PR TITLE
Update install script and docs

### DIFF
--- a/docs/Deployment.md
+++ b/docs/Deployment.md
@@ -100,11 +100,11 @@ spec:
 
 ### Certificate management
 
-Use a tool like [cert-manager](https://cert-manager.io/) or your ingress controller's ACME integration to automatically request Let's Encrypt certificates. Ensure the secret referenced by `tls-secret` exists and is kept up to date.
+Use a tool like [cert-manager](https://cert-manager.io/) or your ingress controller's ACME integration to automatically request Let's Encrypt certificates. Ensure the secret referenced by `tls-secret` exists and is kept up to date. When running the included Nginx or Traefik examples outside Kubernetes, copy your certificate files into `nginx/certs` or configure Traefik's ACME support accordingly.
 
 ## Versioned images with Helm
 
-An example `values.yaml` could look like:
+An example `values.yaml` could look like (also provided as `k8s/values-example.yaml`):
 
 ```yaml
 backendImage:
@@ -125,6 +125,16 @@ Kustomize users can achieve the same by applying an `image` patch that sets the
 tag for each deployment.
 
 Refer to [Setup](Setup.md) for local development. For metrics and dashboards see [Monitoring](Monitoring.md).
+
+## Systemd
+
+For bare-metal deployments the worker can run as a systemd service. The unit file
+`deploy/worker.service` and the helper script `scripts/install_worker_service.sh`
+install the service under `/etc/systemd/system`. Step-by-step instructions and
+customization hints are provided in
+[`Todo-fuer-User.md`](Todo-fuer-User.md). The service expects the same
+environment variables that are used by the Docker Compose setup and Kubernetes
+manifests.
 
 ## Produktivbetrieb
 

--- a/docs/Todo-fuer-User.md
+++ b/docs/Todo-fuer-User.md
@@ -9,11 +9,11 @@ Die folgenden Schritte richten den Service unter systemd ein.
    cargo build --release --bin worker --features worker-bin
    ```
 
-2. **Service installieren** – das Skript `scripts/install_worker_service.sh` kopiert die Unit-Datei `deploy/worker.service` nach `/etc/systemd/system/worker.service` und legt unter `/opt/crPipeline` die benötigten Dateien an.
+2. **Service installieren** – das Skript `scripts/install_worker_service.sh` kopiert die Unit-Datei `deploy/worker.service` nach `/etc/systemd/system/worker.service`, legt unter `/opt/crPipeline` die benötigten Dateien an und erzeugt bei Bedarf automatisch den Systemnutzer `crpipeline`.
    ```bash
    sudo ./scripts/install_worker_service.sh
    ```
-   Passe `WorkingDirectory` und `User` in der Unit-Datei bei Bedarf an, bevor du das Skript ausführst.
+   Passe die Pfade über die Umgebungsvariablen `TARGET` und `UNIT_FILE` oder den Benutzernamen über `SERVICE_USER` an, falls andere Werte gewünscht sind.
 
 3. **Dienst starten und Status prüfen**
    ```bash

--- a/k8s/values-example.yaml
+++ b/k8s/values-example.yaml
@@ -1,0 +1,6 @@
+backendImage:
+  repository: myorg/backend
+  tag: v1.0.0
+frontendImage:
+  repository: myorg/frontend
+  tag: v1.0.0

--- a/scripts/install_worker_service.sh
+++ b/scripts/install_worker_service.sh
@@ -5,10 +5,22 @@ set -e
 # Run from repository root
 cd "$(dirname "$0")/.."
 
-TARGET=/opt/crPipeline
-UNIT_FILE=/etc/systemd/system/worker.service
+# Configurable paths
+TARGET=${TARGET:-/opt/crPipeline}
+UNIT_FILE=${UNIT_FILE:-/etc/systemd/system/worker.service}
+SERVICE_USER=${SERVICE_USER:-crpipeline}
+SERVICE_GROUP=${SERVICE_GROUP:-$SERVICE_USER}
 
 sudo mkdir -p "$TARGET/scripts"
+
+# Create service user and group if missing
+if ! getent group "$SERVICE_GROUP" >/dev/null; then
+    sudo groupadd --system "$SERVICE_GROUP"
+fi
+if ! id "$SERVICE_USER" >/dev/null 2>&1; then
+    sudo useradd --system --gid "$SERVICE_GROUP" --home "$TARGET" \
+        --shell /usr/sbin/nologin "$SERVICE_USER"
+fi
 
 # Copy files for reference
 sudo cp deploy/worker.service "$TARGET/worker.service"
@@ -16,8 +28,11 @@ sudo cp scripts/worker_service.sh "$TARGET/scripts/"
 
 sudo chmod +x "$TARGET/scripts/worker_service.sh"
 
-# Install systemd unit
-sudo cp deploy/worker.service "$UNIT_FILE"
+# Install systemd unit with adjusted paths
+sudo sed -e "s|WorkingDirectory=.*|WorkingDirectory=$TARGET|" \
+         -e "s|ExecStart=.*|ExecStart=$TARGET/scripts/worker_service.sh|" \
+         -e "s|User=.*|User=$SERVICE_USER|" \
+         deploy/worker.service | sudo tee "$UNIT_FILE" >/dev/null
 
 sudo systemctl daemon-reload
-sudo systemctl enable --now worker.service
+sudo systemctl enable --now "$(basename "$UNIT_FILE")"


### PR DESCRIPTION
## Summary
- add user/group creation and configurable paths to `install_worker_service.sh`
- document systemd usage and TLS certificate setup
- reference example values file for Helm
- provide `k8s/values-example.yaml` for Helm deployments
- update systemd instructions for new script features

## Testing
- `cargo test --manifest-path backend/Cargo.toml --all-targets` *(fails: PoolTimedOut)*
- `npm test --prefix frontend` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686a66c740b083338ed22738055f8eeb