### PR TITLE
Integrate worker instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ Multi-tenant document analysis platform built with Rust and Svelte.
 - [Architecture](docs/Architecture.md)
 - [Environment](docs/Environment.md)
 - [Setup](docs/Setup.md)
+- [Worker als Dienst](docs/Setup.md#worker-als-dienst)
 - [Security](docs/Security.md)
 - [Continuous Integration](docs/Continuous_Integration.md)
 - [Deployment](docs/Deployment.md)

--- a/docs/Setup.md
+++ b/docs/Setup.md
@@ -60,3 +60,77 @@ Run `scripts/seed_demo.sh` afterwards to insert example documents stored under `
 
 For production instructions see [Deployment](Deployment.md). To expose metrics and dashboards consult [Monitoring](Monitoring.md).
 
+## Worker als Dienst
+
+Der Hintergrund-Worker kann dauerhaft als systemd-Dienst laufen.
+
+1. **Worker-Binary erstellen**
+   ```bash
+   cargo build --release --bin worker --features worker-bin
+   ```
+
+2. **Service installieren** – das Skript `scripts/install_worker_service.sh`
+   kopiert die Unit-Datei `deploy/worker.service` nach `/etc/systemd/system/worker.service`,
+   legt unter `/opt/crPipeline` die notwendigen Dateien an und erzeugt bei Bedarf
+   automatisch den Systemnutzer `crpipeline`.
+   ```bash
+   sudo ./scripts/install_worker_service.sh
+   ```
+   Passe die Pfade über die Umgebungsvariablen `TARGET` und `UNIT_FILE` oder den
+   Benutzernamen über `SERVICE_USER` an, falls andere Werte gewünscht sind.
+
+3. **Dienst starten und Status prüfen**
+   ```bash
+   sudo systemctl daemon-reload
+   sudo systemctl enable --now worker.service
+   sudo systemctl status worker.service
+   ```
+
+4. **Umgebungsvariablen setzen** – `scripts/worker_service.sh` lädt standardmäßig
+   `backend/.env`. Lege diese Datei unter `/opt/crPipeline` ab oder setze in
+   `worker.service` die Variable `ENV_FILE`, z.B.:
+   ```
+   Environment=ENV_FILE=/opt/crPipeline/backend/.env.prod
+   ```
+
+5. **Logrotate einrichten** – um Logdateien in `/var/log/worker.log` zu rotieren,
+   kann folgende Konfiguration unter `/etc/logrotate.d/worker` abgelegt werden:
+   ```
+   /var/log/worker.log {
+       daily
+       rotate 7
+       compress
+       missingok
+       notifempty
+       copytruncate
+   }
+   ```
+   Ergänze dazu in `worker.service` die Zeile `StandardOutput=append:/var/log/worker.log`.
+
+6. **Neustartstrategie** – in `deploy/worker.service` ist `Restart=always` gesetzt.
+   Damit startet systemd den Worker automatisch neu, falls er unerwartet beendet
+   wird oder beim Systemstart noch nicht läuft.
+
+Alternativ kann die Installation auch manuell erfolgen:
+```bash
+sudo mkdir -p /opt/crPipeline/scripts
+sudo cp scripts/worker_service.sh /opt/crPipeline/scripts/
+sudo cp deploy/worker.service /etc/systemd/system/worker.service
+sudo chmod +x /opt/crPipeline/scripts/worker_service.sh
+sudo systemctl daemon-reload
+sudo systemctl enable --now worker.service
+```
+
+## Statische Assets ausliefern
+
+Um die gebaute Weboberfläche im Produktivbetrieb bereitzustellen,
+sollten die Dateien aus `frontend/dist` von einem Webserver wie nginx
+ausgeliefert werden. Baue das Frontend zuvor mit dem DaisyUI-Schritt:
+
+```bash
+npm run build:prod --prefix frontend
+```
+
+Kopiere danach den Inhalt von `frontend/dist` an den Ort, den dein Webserver
+als Dokumentenwurzel nutzt oder binde das Verzeichnis als Volume ein.
+


### PR DESCRIPTION
## Summary
- integrate Todo-fuer-User instructions into Setup
- add Worker-as-a-service section
- link new docs from README

## Testing
- `cargo test --manifest-path backend/Cargo.toml --all-targets` *(fails: borrowed value does not live long enough)*

------
https://chatgpt.com/codex/tasks/task_e_686a7736e99c83339fd80b1322f71386