### PR TITLE
Add caching for pipelines

### DIFF
--- a/backend/src/handlers/job.rs
+++ b/backend/src/handlers/job.rs
@@ -95,9 +95,9 @@ async fn org_job_events(path: web::Path<Uuid>) -> Sse<ChannelStream> {
     if conn.subscribe("job_status").await.is_err() {
         return sse::channel(0).1;
     }
-    let mut stream = conn.on_message();
     let (tx, rx) = sse::channel(10);
     actix_web::rt::spawn(async move {
+        let mut stream = conn.on_message();
         while let Some(msg) = stream.next().await {
             if let Ok(payload) = msg.get_payload::<String>() {
                 if let Ok(event) = serde_json::from_str::<JobEvent>(&payload) {

--- a/backend/src/models/pipeline.rs
+++ b/backend/src/models/pipeline.rs
@@ -1,9 +1,9 @@
-use serde::Serialize;
+use serde::{Serialize, Deserialize};
 use sqlx::{FromRow, PgPool};
 use uuid::Uuid;
 
 /// Defines a sequence of stages to run on a document.
-#[derive(Serialize, FromRow, Debug)]
+#[derive(Serialize, Deserialize, FromRow, Debug, Clone)]
 pub struct Pipeline {
     pub id: Uuid,
     pub org_id: Uuid,


### PR DESCRIPTION
## Summary
- add Redis/DashMap cache support for pipeline lists
- invalidate cache on pipeline create, update, delete or clone
- fix job events streaming by moving connection into spawned task
- derive `Deserialize` for `Pipeline`

## Testing
- `cargo test --manifest-path backend/Cargo.toml` *(fails: `EnvFilter` missing)*

------
https://chatgpt.com/codex/tasks/task_e_686a91464d3883339a1cdf17bd0b2478