### PR TITLE
Add Playwright workflows

### DIFF
--- a/frontend/e2e/admin_workflow.workflow.ts
+++ b/frontend/e2e/admin_workflow.workflow.ts
@@ -1,0 +1,38 @@
+import { test, expect } from '@playwright/test';
+
+// Admin user invites another user and updates their role
+
+test('admin invitation and role change', async ({ page }) => {
+  await page.goto('/login');
+  await page.fill('input[type=email]', 'demo@example.com');
+  await page.fill('input[type=password]', 'password');
+  await page.click('button[type=submit]');
+  await page.waitForURL('/dashboard');
+
+  await page.goto('/admin');
+  await page.click('text=Rollen\xC3\xA4nderungen');
+  await page.click('text=Benutzer einladen');
+
+  const email = `e2e-${Date.now()}@example.com`;
+  await page.fill('#invite-email', email);
+  const orgSelect = page.locator('#invite-org-select');
+  if (await orgSelect.count()) {
+    await orgSelect.selectOption({ index: 0 });
+  }
+  await page.click('text=Send Invitation');
+  await expect(page.locator('text=Invite New User')).toBeHidden({ timeout: 10000 });
+
+  const row = page.locator('tr', { hasText: email });
+  await expect(row).toBeVisible({ timeout: 10000 });
+  await row.locator('text=Edit Role').click();
+
+  await page.selectOption('#role-select', 'org_admin');
+  const modalOrgSelect = page.locator('#org-select');
+  if (await modalOrgSelect.count()) {
+    await modalOrgSelect.selectOption({ index: 0 });
+  }
+  await page.click('text=Save Changes');
+  await expect(page.locator('text=Edit User:')).toBeHidden({ timeout: 10000 });
+
+  await expect(row).toContainText('org_admin');
+});

--- a/frontend/e2e/document_analysis.workflow.ts
+++ b/frontend/e2e/document_analysis.workflow.ts
@@ -1,0 +1,71 @@
+import { test, expect } from '@playwright/test';
+import fs from 'fs';
+
+// Full document upload and analysis flow
+
+test('document upload triggers analysis pipeline', async ({ page }, testInfo) => {
+  await page.goto('/login');
+  await page.fill('input[type=email]', 'demo@example.com');
+  await page.fill('input[type=password]', 'password');
+  await page.click('button[type=submit]');
+  await page.waitForURL('/dashboard');
+
+  // Get organization ID of logged in user
+  const orgId = await page.evaluate(async () => {
+    const res = await fetch('/api/me');
+    const data = await res.json();
+    return data.org_id as string;
+  });
+
+  // Create simple pipeline via API
+  const pipelineId = await page.evaluate(async (orgId) => {
+    const res = await fetch('/api/pipelines', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ org_id: orgId, name: 'E2E Pipeline', stages: [{ type: 'parse' }] })
+    });
+    const data = await res.json();
+    return data.id as string;
+  }, orgId);
+
+  // Prepare file and send upload request from browser context
+  const filePath = testInfo.outputPath('sample.txt');
+  fs.writeFileSync(filePath, 'hello world');
+  const fileBase64 = fs.readFileSync(filePath, 'base64');
+
+  const jobId = await page.evaluate(async ({ orgId, pipelineId, fileBase64 }) => {
+    const bytes = Uint8Array.from(atob(fileBase64), c => c.charCodeAt(0));
+    const file = new File([bytes], 'sample.txt', { type: 'text/plain' });
+    const fd = new FormData();
+    fd.append('file', file);
+    const uploadRes = await fetch(`/api/upload?org_id=${orgId}&pipeline_id=${pipelineId}&is_target=true`, {
+      method: 'POST',
+      body: fd
+    });
+    const doc = await uploadRes.json();
+    for (let i = 0; i < 30; i++) {
+      const list = await fetch(`/api/jobs/${orgId}`).then(r => r.json());
+      const job = list.find((j: any) => j.document_id === doc.id);
+      if (job) return job.id as string;
+      await new Promise(res => setTimeout(res, 1000));
+    }
+    return null;
+  }, { orgId, pipelineId, fileBase64 });
+
+  expect(jobId).not.toBeNull();
+
+  await page.waitForFunction(async (id => {
+    const r = await fetch(`/api/jobs/${id}/details`);
+    if (!r.ok) return false;
+    const d = await r.json();
+    return d.status === 'completed';
+  }), jobId, { timeout: 90000 });
+
+  const outputCount = await page.evaluate(async id => {
+    const res = await fetch(`/api/jobs/${id}/details`);
+    const data = await res.json();
+    return data.stage_outputs.length as number;
+  }, jobId);
+
+  expect(outputCount).toBeGreaterThan(0);
+});

--- a/frontend/e2e/global-setup.ts
+++ b/frontend/e2e/global-setup.ts
@@ -2,6 +2,8 @@ import { FullConfig } from '@playwright/test';
 import { execSync } from 'child_process';
 import http from 'http';
 import path from 'path';
+import { fileURLToPath } from 'url';
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
 async function waitFor(url: string, timeout = 60000) {
   const start = Date.now();

--- a/frontend/e2e/global-teardown.ts
+++ b/frontend/e2e/global-teardown.ts
@@ -1,5 +1,7 @@
 import { execSync } from 'child_process';
 import path from 'path';
+import { fileURLToPath } from 'url';
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
 export default async function globalTeardown() {
   const root = path.join(__dirname, '..', '..');

--- a/frontend/playwright.config.ts
+++ b/frontend/playwright.config.ts
@@ -1,9 +1,11 @@
 import { defineConfig } from '@playwright/test';
 import path from 'path';
+import { fileURLToPath } from 'url';
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
 export default defineConfig({
   testDir: './e2e',
-  testMatch: /.*\.e2e\.ts/,
+  testMatch: /.*\.(e2e|workflow)\.ts/,
   globalSetup: path.join(__dirname, 'e2e/global-setup.ts'),
   globalTeardown: path.join(__dirname, 'e2e/global-teardown.ts'),
   use: {


### PR DESCRIPTION
## Summary
- add analysis and admin Playwright workflow tests
- support new *.workflow.ts pattern and fix ES module dirname usage

## Testing
- `npm install --prefix frontend`
- `npm run lint --prefix frontend` *(fails: svelte-check found errors)*
- `npm test --prefix frontend` *(fails: several unit tests failed)*
- `npm run build --prefix frontend`
- `npm run e2e --prefix frontend` *(fails: docker not found)*

------
https://chatgpt.com/codex/tasks/task_e_686a9145de3c8333b4be9f81a42eff14