### PR TITLE
Add automatic endpoint metrics

### DIFF
--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -12,6 +12,7 @@ use backend::email;
 
 use backend::handlers;
 use backend::middleware::{
+    metrics::Metrics,
     jwt::init_jwt_secret,
     rate_limit::RateLimit,
     csrf_check::{CsrfCheck, init_csrf_token},
@@ -65,6 +66,7 @@ async fn main() -> std::io::Result<()> {
             .wrap(cors)
             .wrap(RateLimit)
             .wrap(CsrfCheck)
+            .wrap(Metrics)
             .wrap(prometheus.clone())
             .app_data(web::Data::new(pool.clone()))
             .app_data(web::Data::new(s3_client.clone()))

--- a/backend/src/metrics.rs
+++ b/backend/src/metrics.rs
@@ -32,6 +32,22 @@ pub static JOB_HISTOGRAM: Lazy<HistogramVec> = Lazy::new(|| {
     HistogramVec::new(opts, &["status"]).unwrap()
 });
 
+pub static HTTP_REQUEST_COUNTER: Lazy<IntCounterVec> = Lazy::new(|| {
+    let opts = Opts::new(
+        "http_requests_total",
+        "Total number of HTTP requests",
+    );
+    IntCounterVec::new(opts, &["method", "endpoint", "status"]).unwrap()
+});
+
+pub static HTTP_REQUEST_HISTOGRAM: Lazy<HistogramVec> = Lazy::new(|| {
+    let opts = HistogramOpts::new(
+        "http_request_duration_seconds",
+        "HTTP request latency in seconds",
+    );
+    HistogramVec::new(opts, &["method", "endpoint", "status"]).unwrap()
+});
+
 pub fn register_metrics(registry: &Registry) {
     registry
         .register(Box::new(AUTH_FAILURE_COUNTER.clone()))
@@ -44,5 +60,11 @@ pub fn register_metrics(registry: &Registry) {
         .unwrap();
     registry
         .register(Box::new(JOB_HISTOGRAM.clone()))
+        .unwrap();
+    registry
+        .register(Box::new(HTTP_REQUEST_COUNTER.clone()))
+        .unwrap();
+    registry
+        .register(Box::new(HTTP_REQUEST_HISTOGRAM.clone()))
         .unwrap();
 }

--- a/backend/src/middleware/metrics.rs
+++ b/backend/src/middleware/metrics.rs
@@ -1,0 +1,64 @@
+use actix_service::{forward_ready, Service, Transform};
+use actix_web::dev::{ServiceRequest, ServiceResponse};
+use actix_web::Error;
+use futures_util::future::{ready, LocalBoxFuture, Ready};
+use std::rc::Rc;
+use std::time::Instant;
+
+use crate::metrics::{HTTP_REQUEST_COUNTER, HTTP_REQUEST_HISTOGRAM};
+
+pub struct Metrics;
+
+impl<S, B> Transform<S, ServiceRequest> for Metrics
+where
+    S: Service<ServiceRequest, Response = ServiceResponse<B>, Error = Error> + 'static,
+    B: 'static,
+{
+    type Response = ServiceResponse<B>;
+    type Error = Error;
+    type Transform = MetricsMiddleware<S>;
+    type InitError = ();
+    type Future = Ready<Result<Self::Transform, Self::InitError>>;
+
+    fn new_transform(&self, service: S) -> Self::Future {
+        ready(Ok(MetricsMiddleware { service: Rc::new(service) }))
+    }
+}
+
+pub struct MetricsMiddleware<S> {
+    service: Rc<S>,
+}
+
+impl<S, B> Service<ServiceRequest> for MetricsMiddleware<S>
+where
+    S: Service<ServiceRequest, Response = ServiceResponse<B>, Error = Error> + 'static,
+    B: 'static,
+{
+    type Response = ServiceResponse<B>;
+    type Error = Error;
+    type Future = LocalBoxFuture<'static, Result<Self::Response, Self::Error>>;
+
+    forward_ready!(service);
+
+    fn call(&self, req: ServiceRequest) -> Self::Future {
+        let srv = Rc::clone(&self.service);
+        let method = req.method().clone();
+        let endpoint = req
+            .match_pattern()
+            .map(|s| s.to_string())
+            .unwrap_or_else(|| req.path().to_string());
+        Box::pin(async move {
+            let start = Instant::now();
+            let res = srv.call(req).await?;
+            let duration = start.elapsed().as_secs_f64();
+            let status = res.status().as_u16().to_string();
+            HTTP_REQUEST_COUNTER
+                .with_label_values(&[method.as_str(), &endpoint, &status])
+                .inc();
+            HTTP_REQUEST_HISTOGRAM
+                .with_label_values(&[method.as_str(), &endpoint, &status])
+                .observe(duration);
+            Ok(res)
+        })
+    }
+}

--- a/backend/src/middleware/mod.rs
+++ b/backend/src/middleware/mod.rs
@@ -1,3 +1,4 @@
+pub mod metrics;
 pub mod jwt;
 pub mod auth;
 pub mod rate_limit;


### PR DESCRIPTION
## Summary
- add HTTP request counters and histograms
- provide middleware to record per-endpoint metrics
- register the new metrics and enable middleware in the server

## Testing
- `cargo test --quiet` *(fails: build takes too long in environment)*

------
https://chatgpt.com/codex/tasks/task_e_686a9ca20a248333b057736ce9d7dcf4