### PR TITLE
Add audit log table and pagination

### DIFF
--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -24,7 +24,7 @@ aws-sdk-s3 = "0.31"
 futures-util = "0.3"
 actix-web-lab = "0.19"
 tracing = "0.1"
-tracing-subscriber = { version = "0.3", features = ["fmt", "json"] }
+tracing-subscriber = { version = "0.3", features = ["fmt", "json", "env-filter"] }
 anyhow = "1"
 lopdf = "0.32"
 dashmap = "5"

--- a/backend/src/handlers/audit.rs
+++ b/backend/src/handlers/audit.rs
@@ -4,17 +4,81 @@ use sqlx::PgPool;
 use uuid::Uuid;
 use crate::middleware::auth::AuthUser;
 use crate::models::AuditLog;
+use serde::{Deserialize, Serialize};
+
+#[derive(Deserialize)]
+struct PaginationParams {
+    page: Option<i64>,
+    limit: Option<i64>,
+}
+
+#[derive(Serialize)]
+struct PaginatedAuditLogs {
+    items: Vec<AuditLog>,
+    total_items: i64,
+    page: i64,
+    per_page: i64,
+    total_pages: i64,
+}
 
 #[get("/audit/{org_id}")]
-async fn list_logs(path: web::Path<Uuid>, user: AuthUser, pool: web::Data<PgPool>) -> HttpResponse {
+async fn list_logs(
+    path: web::Path<Uuid>,
+    query: web::Query<PaginationParams>,
+    user: AuthUser,
+    pool: web::Data<PgPool>,
+) -> HttpResponse {
     if *path != user.org_id {
         return ApiError::new("Unauthorized", StatusCode::UNAUTHORIZED)
             .error_response();
     }
-    match AuditLog::list_by_org(pool.as_ref(), *path).await {
-        Ok(list) => HttpResponse::Ok().json(list),
-        Err(_) => ApiError::new("Failed to retrieve logs", StatusCode::INTERNAL_SERVER_ERROR)
-            .error_response(),
+
+    let page = query.page.unwrap_or(1).max(1);
+    let limit = query.limit.unwrap_or(20).max(1).min(100);
+    let offset = (page - 1) * limit;
+
+    let total_items: i64 = match sqlx::query_scalar(
+        "SELECT COUNT(*) FROM audit_logs WHERE org_id=$1",
+    )
+    .bind(*path)
+    .fetch_one(pool.as_ref())
+    .await
+    {
+        Ok(count) => count,
+        Err(e) => {
+            log::error!("Failed to count audit logs for org {}: {:?}", *path, e);
+            return ApiError::new(
+                "Failed to retrieve logs",
+                StatusCode::INTERNAL_SERVER_ERROR,
+            )
+            .error_response();
+        }
+    };
+
+    match sqlx::query_as::<_, AuditLog>(
+        "SELECT * FROM audit_logs WHERE org_id=$1 ORDER BY created_at DESC LIMIT $2 OFFSET $3",
+    )
+    .bind(*path)
+    .bind(limit)
+    .bind(offset)
+    .fetch_all(pool.as_ref())
+    .await
+    {
+        Ok(logs) => {
+            let total_pages = (total_items as f64 / limit as f64).ceil() as i64;
+            HttpResponse::Ok().json(PaginatedAuditLogs {
+                items: logs,
+                total_items,
+                page,
+                per_page: limit,
+                total_pages,
+            })
+        }
+        Err(e) => {
+            log::error!("Failed to fetch audit logs for org {}: {:?}", *path, e);
+            ApiError::new("Failed to retrieve logs", StatusCode::INTERNAL_SERVER_ERROR)
+                .error_response()
+        }
     }
 }
 

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -353,6 +353,18 @@ paths:
           required: true
           schema:
             type: string
+        - name: page
+          in: query
+          required: false
+          schema:
+            type: integer
+            minimum: 1
+        - name: limit
+          in: query
+          required: false
+          schema:
+            type: integer
+            minimum: 1
       responses:
         '200':
           description: Logs

--- a/frontend/src/lib/api/index.ts
+++ b/frontend/src/lib/api/index.ts
@@ -955,7 +955,10 @@ export interface paths {
         /** List audit logs for organization */
         get: {
             parameters: {
-                query?: never;
+                query?: {
+                    page?: number;
+                    limit?: number;
+                };
                 header?: never;
                 path: {
                     org_id: string;

--- a/frontend/src/lib/components/AuditLogTable.svelte
+++ b/frontend/src/lib/components/AuditLogTable.svelte
@@ -1,0 +1,92 @@
+<script lang="ts">
+  import { onMount } from 'svelte';
+  import DataTable, { type TableHeader } from './DataTable.svelte';
+  import PaginationControls from './PaginationControls.svelte';
+  import { apiFetch } from '$lib/utils/apiUtils';
+
+  export let orgId: string;
+
+  interface AuditLog {
+    id: string;
+    org_id: string;
+    user_id: string;
+    action: string;
+    created_at: string;
+
+    created_at_formatted?: string;
+    user_id_short?: string;
+  }
+
+  let logs: AuditLog[] = [];
+  let isLoading = true;
+  let error: string | null = null;
+
+  let currentPage = 1;
+  let totalPages = 0;
+  let perPage = 20;
+  let totalItems = 0;
+
+  const headers: TableHeader[] = [
+    { key: 'created_at_formatted', label: 'Timestamp', sortable: false },
+    { key: 'user_id_short', label: 'User', sortable: false },
+    { key: 'action', label: 'Action', sortable: false }
+  ];
+
+  async function loadLogs(page = 1) {
+    if (!orgId) return;
+    isLoading = true;
+    currentPage = page;
+    try {
+      const res = await apiFetch(`/api/audit/${orgId}?page=${page}&limit=${perPage}`);
+      const data = await res.json();
+      logs = data.items.map((l: AuditLog) => ({
+        ...l,
+        created_at_formatted: new Date(l.created_at).toLocaleString(),
+        user_id_short: l.user_id.substring(0, 8) + '...'
+      }));
+      totalPages = data.total_pages;
+      perPage = data.per_page;
+      totalItems = data.total_items;
+      error = null;
+    } catch (e: any) {
+      error = e.message;
+      logs = [];
+      totalPages = 0;
+      totalItems = 0;
+    } finally {
+      isLoading = false;
+    }
+  }
+
+  function handlePageChange(e: CustomEvent<{ page: number }>) {
+    if (e.detail.page !== currentPage) loadLogs(e.detail.page);
+  }
+
+  onMount(() => {
+    loadLogs();
+  });
+</script>
+
+<DataTable
+  {headers}
+  items={logs}
+  keyField="id"
+  tableSortable={false}
+  currentPage={currentPage}
+  totalPages={totalPages}
+  totalItems={totalItems}
+  itemsPerPage={perPage}
+  emptyStateMessage={isLoading ? 'Loading logs...' : (error ? `Error: ${error}` : 'No logs found.')}
+  tableContainerClass="bg-neutral-800/40 backdrop-blur-sm shadow-lg rounded-xl border border-neutral-700/50 overflow-hidden"
+  tableClass="min-w-full divide-y divide-neutral-700/30"
+>
+  <span slot="cell-user_id_short" let:item title={item.user_id}>{item.user_id_short}</span>
+  <span slot="cell-created_at_formatted" let:item class="text-xs text-gray-400">{item.created_at_formatted}</span>
+  <div slot="paginationControls" let:currentPageProps let:totalPagesProps>
+    <PaginationControls
+      currentPage={currentPageProps}
+      totalPages={totalPagesProps}
+      on:pageChange={handlePageChange}
+    />
+  </div>
+</DataTable>

--- a/frontend/src/lib/types/api.ts
+++ b/frontend/src/lib/types/api.ts
@@ -44,3 +44,11 @@ export interface OrgSettings {
   prompt_templates?: { id?: string; name: string; text: string }[] | null;
   ai_custom_headers?: { id: string; name: string; value: string }[] | null;
 }
+
+export interface AuditLog {
+  id: string;
+  org_id: string;
+  user_id: string;
+  action: string;
+  created_at: string;
+}


### PR DESCRIPTION
## Summary
- add pagination support to `/audit/{org_id}` endpoint
- document new query parameters in `openapi.yaml`
- regenerate frontend API types
- add AuditLog model timestamp and new paginated query
- add `AuditLogTable` Svelte component for viewing logs
- enable `env-filter` feature for tracing subscriber

## Testing
- `cargo check --color=never`
- `npm run lint` *(fails: svelte-check found 143 errors)*

------
https://chatgpt.com/codex/tasks/task_e_686a9ca542b883338eab04753e60a294