### PR TITLE
Add request metrics middleware

### DIFF
--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -15,6 +15,7 @@ use backend::middleware::{
     jwt::init_jwt_secret,
     rate_limit::RateLimit,
     csrf_check::{CsrfCheck, init_csrf_token},
+    request_metrics::RequestMetrics,
 };
 use tracing_subscriber::{fmt, EnvFilter};
 
@@ -65,6 +66,7 @@ async fn main() -> std::io::Result<()> {
             .wrap(cors)
             .wrap(RateLimit)
             .wrap(CsrfCheck)
+            .wrap(RequestMetrics)
             .wrap(prometheus.clone())
             .app_data(web::Data::new(pool.clone()))
             .app_data(web::Data::new(s3_client.clone()))

--- a/backend/src/metrics.rs
+++ b/backend/src/metrics.rs
@@ -1,7 +1,5 @@
 use once_cell::sync::Lazy;
-use prometheus::{
-    HistogramOpts, HistogramVec, IntCounter, IntCounterVec, Opts, Registry,
-};
+use prometheus::{HistogramOpts, HistogramVec, IntCounter, IntCounterVec, Opts, Registry};
 
 pub static AUTH_FAILURE_COUNTER: Lazy<IntCounterVec> = Lazy::new(|| {
     let opts = Opts::new("login_failures_total", "Total failed login attempts");
@@ -32,17 +30,31 @@ pub static JOB_HISTOGRAM: Lazy<HistogramVec> = Lazy::new(|| {
     HistogramVec::new(opts, &["status"]).unwrap()
 });
 
+pub static REQUEST_COUNTER: Lazy<IntCounterVec> = Lazy::new(|| {
+    let opts = Opts::new(
+        "http_requests_total",
+        "Total number of HTTP requests by endpoint",
+    );
+    IntCounterVec::new(opts, &["method", "endpoint", "status"]).unwrap()
+});
+
+pub static REQUEST_HISTOGRAM: Lazy<HistogramVec> = Lazy::new(|| {
+    let opts = HistogramOpts::new(
+        "http_request_duration_seconds",
+        "HTTP request duration by endpoint",
+    );
+    HistogramVec::new(opts, &["method", "endpoint", "status"]).unwrap()
+});
+
 pub fn register_metrics(registry: &Registry) {
-    registry
-        .register(Box::new(AUTH_FAILURE_COUNTER.clone()))
-        .unwrap();
+    registry.register(Box::new(AUTH_FAILURE_COUNTER.clone())).unwrap();
     registry
         .register(Box::new(RATE_LIMIT_FALLBACK_COUNTER.clone()))
         .unwrap();
     registry
         .register(Box::new(STAGE_HISTOGRAM.clone()))
         .unwrap();
-    registry
-        .register(Box::new(JOB_HISTOGRAM.clone()))
-        .unwrap();
+    registry.register(Box::new(JOB_HISTOGRAM.clone())).unwrap();
+    registry.register(Box::new(REQUEST_COUNTER.clone())).unwrap();
+    registry.register(Box::new(REQUEST_HISTOGRAM.clone())).unwrap();
 }

--- a/backend/src/middleware/mod.rs
+++ b/backend/src/middleware/mod.rs
@@ -2,3 +2,4 @@ pub mod jwt;
 pub mod auth;
 pub mod rate_limit;
 pub mod csrf_check;
+pub mod request_metrics;

--- a/backend/src/middleware/request_metrics.rs
+++ b/backend/src/middleware/request_metrics.rs
@@ -1,0 +1,68 @@
+use actix_service::{forward_ready, Service, Transform};
+use actix_web::dev::{ServiceRequest, ServiceResponse};
+use actix_web::Error;
+use futures_util::future::{ready, LocalBoxFuture, Ready};
+use std::rc::Rc;
+use std::time::Instant;
+
+use crate::metrics::{REQUEST_COUNTER, REQUEST_HISTOGRAM};
+
+pub struct RequestMetrics;
+
+impl<S, B> Transform<S, ServiceRequest> for RequestMetrics
+where
+    S: Service<ServiceRequest, Response = ServiceResponse<B>, Error = Error> + 'static,
+    B: 'static,
+{
+    type Response = ServiceResponse<B>;
+    type Error = Error;
+    type Transform = RequestMetricsMiddleware<S>;
+    type InitError = ();
+    type Future = Ready<Result<Self::Transform, Self::InitError>>;
+
+    fn new_transform(&self, service: S) -> Self::Future {
+        ready(Ok(RequestMetricsMiddleware {
+            service: Rc::new(service),
+        }))
+    }
+}
+
+pub struct RequestMetricsMiddleware<S> {
+    service: Rc<S>,
+}
+
+impl<S, B> Service<ServiceRequest> for RequestMetricsMiddleware<S>
+where
+    S: Service<ServiceRequest, Response = ServiceResponse<B>, Error = Error> + 'static,
+    B: 'static,
+{
+    type Response = ServiceResponse<B>;
+    type Error = Error;
+    type Future = LocalBoxFuture<'static, Result<Self::Response, Self::Error>>;
+
+    forward_ready!(service);
+
+    fn call(&self, req: ServiceRequest) -> Self::Future {
+        let srv = Rc::clone(&self.service);
+        let path = req
+            .match_pattern()
+            .map(|s| s.to_string())
+            .unwrap_or_else(|| req.path().to_string());
+        let method = req.method().as_str().to_string();
+        let start = Instant::now();
+
+        Box::pin(async move {
+            let res = srv.call(req).await?;
+            let status = res.status().as_u16().to_string();
+            let elapsed = start.elapsed().as_secs_f64();
+            REQUEST_COUNTER
+                .with_label_values(&[&method, &path, &status])
+                .inc();
+            REQUEST_HISTOGRAM
+                .with_label_values(&[&method, &path, &status])
+                .observe(elapsed);
+            Ok(res)
+        })
+    }
+}
+


### PR DESCRIPTION
## Summary
- instrument requests with a new `RequestMetrics` middleware
- add counters and histograms for HTTP requests
- register new middleware in main app

## Testing
- `cargo check` *(fails: process interrupted)*

------
https://chatgpt.com/codex/tasks/task_e_686aa27562c083338db2a73e5e49ea8e