### PR TITLE
Standardize toast error handling

### DIFF
--- a/frontend/src/lib/components/AnalysisJobDetail.svelte
+++ b/frontend/src/lib/components/AnalysisJobDetail.svelte
@@ -5,6 +5,7 @@
   import Modal from './Modal.svelte';
   import * as Diff from 'diff'; // Import the diff library
   import { apiFetch } from '$lib/utils/apiUtils';
+  import { errorStore } from '$lib/utils/errorStore';
 
   export let jobId: string;
 
@@ -414,15 +415,15 @@
 
   async function copyToClipboard(text: string | null, type: string) {
     if (!text || typeof navigator.clipboard?.writeText !== 'function') {
-      alert('Clipboard API not available or no text to copy.');
+      errorStore.show('Clipboard API not available or no text to copy.');
       return;
     }
     try {
       await navigator.clipboard.writeText(text);
-      alert(`${type} content copied to clipboard!`);
+      // Optionally show success toast here in the future
     } catch (err) {
       console.error(`Failed to copy ${type} to clipboard:`, err);
-      alert(`Failed to copy ${type}. See console for details.`);
+      errorStore.show(`Failed to copy ${type}. See console for details.`);
     }
   }
 
@@ -463,7 +464,7 @@
 
   async function viewStageOutput(output: StageOutput) {
     if (output.output_type !== 'txt' && output.output_type !== 'json') {
-      alert("Viewing is currently supported only for .txt and .json files.");
+      errorStore.show("Viewing is currently supported only for .txt and .json files.");
       return;
     }
 
@@ -547,11 +548,11 @@
       } else {
         throw new Error("Download URL not found in the server response.");
       }
-    } catch (err: any) {
-      console.error("Download failed for output ID", outputId, err);
-      alert(`Could not initiate download: ${err.message}`);
-    }
+  } catch (err: any) {
+    console.error("Download failed for output ID", outputId, err);
+    errorStore.show(`Could not initiate download: ${err.message}`);
   }
+}
 
   function getStatusColor(status: string): string {
     if (status === 'completed' || status === 'success') return 'text-green-400';

--- a/frontend/src/lib/components/DocumentList.svelte
+++ b/frontend/src/lib/components/DocumentList.svelte
@@ -5,6 +5,7 @@ import type { TableHeader } from './DataTable.svelte';
 import PaginationControls from './PaginationControls.svelte';
 import { onMount } from 'svelte';
 import { apiFetch } from '$lib/utils/apiUtils';
+import { errorStore } from '$lib/utils/errorStore';
 import type { Document as APIDocument } from '$lib/types/api';
 
 // Base Document interface matching backend model
@@ -175,7 +176,7 @@ async function downloadDocument(id: string) {
     window.open(url, '_blank');
   } catch (error) {
     console.error("Download error:", error);
-    alert('Error getting download link. See console.');
+    errorStore.show('Error getting download link. See console.');
   }
 }
 
@@ -186,10 +187,10 @@ async function deleteDocument(id: string) {
     if (res.ok) {
       await loadDocuments(currentPage);
     } else {
-      alert('Failed to delete document: ' + (await res.text()));
+      errorStore.show('Failed to delete document: ' + (await res.text()));
     }
   } catch (e: any) {
-    alert(`Error deleting document: ${e.message}`);
+    errorStore.show(`Error deleting document: ${e.message}`);
   }
 }
 </script>

--- a/frontend/src/lib/components/PipelineEditor.svelte
+++ b/frontend/src/lib/components/PipelineEditor.svelte
@@ -3,6 +3,7 @@
   import StageList from './pipeline_editor/StageList.svelte';
   import { onMount, createEventDispatcher } from 'svelte';
   import { apiFetch } from '$lib/utils/apiUtils';
+  import { errorStore } from '$lib/utils/errorStore';
   import type { Stage, Pipeline } from '$lib/types/api';
   import type { EditorPromptTemplate, RegexPatternConfig } from './pipeline_editor/types';
 
@@ -198,11 +199,11 @@
 
   async function savePipeline() {
     if (!pipeline.name.trim()) {
-      alert("Pipeline name is required.");
+      errorStore.show("Pipeline name is required.");
       return;
     }
     if (pipeline.stages.length === 0) {
-      alert("Pipeline must have at least one stage.");
+      errorStore.show("Pipeline must have at least one stage.");
       return;
     }
 
@@ -224,11 +225,11 @@
       } else {
         const errorData = await response.json().catch(() => ({ error: "Unknown error during save." }));
         console.error('Failed to save pipeline:', errorData);
-        alert(`Error saving pipeline: ${errorData.error || response.statusText}`);
+        errorStore.show(`Error saving pipeline: ${errorData.error || response.statusText}`);
       }
     } catch (e: any) {
       console.error('Network or other error saving pipeline:', e);
-      alert(`Network error while saving pipeline: ${e.message}`);
+      errorStore.show(`Network error while saving pipeline: ${e.message}`);
     }
   }
 
@@ -245,10 +246,10 @@
         document.body.dispatchEvent(new CustomEvent('pipelinesUpdated'));
       } else {
         const errorData = await response.json().catch(() => ({ error: 'Unknown error' }));
-        alert(`Error deleting pipeline: ${errorData.error || response.statusText}`);
+        errorStore.show(`Error deleting pipeline: ${errorData.error || response.statusText}`);
       }
     } catch (e: any) {
-      alert(`Network error while deleting pipeline: ${e.message}`);
+      errorStore.show(`Network error while deleting pipeline: ${e.message}`);
     }
   }
 

--- a/frontend/src/lib/components/SettingsForm.svelte
+++ b/frontend/src/lib/components/SettingsForm.svelte
@@ -4,6 +4,7 @@
   import GlassCard from './GlassCard.svelte';
   import ConfirmationModal from './ConfirmationModal.svelte';
   import { apiFetch } from '$lib/utils/apiUtils'; // Import apiFetch
+  import { errorStore } from '$lib/utils/errorStore';
 
   export let orgId: string;
 
@@ -136,11 +137,11 @@
         dispatch('saved', { accentColor: settings.accent_color });
         alert('Settings saved successfully!');
       } else {
-        alert('Failed to save settings: ' + (await res.text()));
+        errorStore.show('Failed to save settings: ' + (await res.text()));
       }
-    } catch (error) {
+    } catch (error: any) {
       console.error('Error saving settings:', error);
-      alert('Error saving settings.');
+      errorStore.show('Error saving settings: ' + error.message);
     }
   }
 

--- a/frontend/src/routes/pipelines/+page.svelte
+++ b/frontend/src/routes/pipelines/+page.svelte
@@ -5,6 +5,7 @@
   import Button from '$lib/components/Button.svelte';
   import GlassCard from '$lib/components/GlassCard.svelte';
   import { apiFetch } from '$lib/utils/apiUtils';
+  import { errorStore } from '$lib/utils/errorStore';
   import { fade } from 'svelte/transition';
 
   // Define Pipeline type consistent with PipelineEditor and backend
@@ -106,7 +107,7 @@
           managePipeline(originalPipeline);
       } else {
           console.error("Could not find original pipeline data or managePipeline context is unavailable.", pipelineToEdit);
-          alert("Error: Could not initiate pipeline editing.");
+          errorStore.show("Error: Could not initiate pipeline editing.");
       }
   }
 
@@ -115,7 +116,7 @@
           managePipeline(null); // Pass null for new pipeline
       } else {
           console.error("managePipeline context is unavailable.");
-          alert("Error: Could not open pipeline editor.");
+          errorStore.show("Error: Could not open pipeline editor.");
       }
   }
 
@@ -128,10 +129,10 @@
               document.body.dispatchEvent(new CustomEvent('pipelinesUpdated'));
           } else {
               const err = await res.json().catch(() => ({ error: res.statusText }));
-              alert(`Error deleting pipeline: ${err.error}`);
+              errorStore.show(`Error deleting pipeline: ${err.error}`);
           }
       } catch (e: any) {
-          alert(`Network error while deleting pipeline: ${e.message}`);
+          errorStore.show(`Network error while deleting pipeline: ${e.message}`);
       }
   }
 
@@ -143,10 +144,10 @@
               document.body.dispatchEvent(new CustomEvent('pipelinesUpdated'));
           } else {
               const err = await res.json().catch(() => ({ error: res.statusText }));
-              alert(`Error cloning pipeline: ${err.error}`);
+              errorStore.show(`Error cloning pipeline: ${err.error}`);
           }
       } catch (e: any) {
-          alert(`Network error while cloning pipeline: ${e.message}`);
+          errorStore.show(`Network error while cloning pipeline: ${e.message}`);
       }
   }
 

--- a/frontend/src/routes/settings/+page.svelte
+++ b/frontend/src/routes/settings/+page.svelte
@@ -4,6 +4,7 @@
   import GlassCard from '$lib/components/GlassCard.svelte';
   import Button from '$lib/components/Button.svelte';
   import { apiFetch } from '$lib/utils/apiUtils';
+  import { errorStore } from '$lib/utils/errorStore';
 
   interface Header { id: string; name: string; value: string; }
 
@@ -63,10 +64,10 @@
         dispatch('settingsUpdated');
         alert('Settings saved.');
       } else {
-        alert('Failed to save settings: ' + (await res.text()));
+        errorStore.show('Failed to save settings: ' + (await res.text()));
       }
     } catch (e: any) {
-      alert('Error saving settings: ' + e.message);
+      errorStore.show('Error saving settings: ' + e.message);
     }
   }
 </script>


### PR DESCRIPTION
## Summary
- show API errors automatically via `errorStore` and add `HttpError`
- replace many `alert()` error messages with toast notifications

## Testing
- `npm test` *(fails: "Tests failed. Watching for file changes...")*

------
https://chatgpt.com/codex/tasks/task_e_686aa275eafc83338bbd274cc5cb0633