### PR TITLE
Enable runtime reload of worker config

### DIFF
--- a/backend/src/bin/worker.rs
+++ b/backend/src/bin/worker.rs
@@ -14,7 +14,10 @@ use serde_json::{self, Value};
 use sqlx::{postgres::PgPoolOptions, PgPool};
 use std::{
     path::{Path, PathBuf},
-    sync::Arc,
+    sync::{
+        atomic::{AtomicUsize, Ordering},
+        Arc,
+    },
     time::{Duration, Instant},
 };
 use tokio::process::Command;
@@ -287,11 +290,12 @@ async fn main() -> Result<()> {
     let pool = Arc::new(pool);
     let s3_client = Arc::new(s3_client);
     let runtime_cfg = WorkerRuntimeConfig::from_env();
-    let concurrency = runtime_cfg.concurrency.max(1);
+    let concurrency = Arc::new(AtomicUsize::new(runtime_cfg.concurrency.max(1)));
+    tokio::spawn(worker::watch_config_changes(Arc::clone(&concurrency)));
     let mut tasks: JoinSet<()> = JoinSet::new();
 
     'outer: loop {
-        if tasks.len() >= concurrency {
+        if tasks.len() >= concurrency.load(Ordering::SeqCst) {
             tokio::select! {
                 _ = &mut shutdown_signal => {
                     info!("Shutdown signal received");


### PR DESCRIPTION
## Summary
- reload worker runtime configuration on SIGHUP
- track concurrency with `AtomicUsize` so it can be updated live

## Testing
- `rustfmt --edition 2021 backend/src/bin/worker.rs backend/src/worker/mod.rs`

------
https://chatgpt.com/codex/tasks/task_e_686aa2782374833393fb977c9e784ed5