### PR TITLE
Implement logout endpoint

### DIFF
--- a/backend/src/handlers/auth.rs
+++ b/backend/src/handlers/auth.rs
@@ -261,6 +261,14 @@ async fn reset_password(data: web::Json<ResetInput>, pool: web::Data<PgPool>) ->
     }
 }
 
+#[post("/logout")]
+async fn logout() -> HttpResponse {
+    let cookie = actix_web::cookie::Cookie::build("token", "")
+        .max_age(ActixDuration::ZERO)
+        .finish();
+    HttpResponse::Ok().cookie(cookie).finish()
+}
+
 pub fn routes(cfg: &mut web::ServiceConfig) {
     cfg.service(register)
         .service(login)

--- a/backend/src/handlers/mod.rs
+++ b/backend/src/handlers/mod.rs
@@ -14,6 +14,7 @@ pub mod admin; // New module
 pub fn init(cfg: &mut web::ServiceConfig) {
     cfg.service(web::scope("/api")
         .configure(auth::routes)
+        .service(auth::logout)
         .configure(org::routes)
         .configure(document::routes)
         .configure(pipeline::routes)

--- a/backend/tests/logout_tests.rs
+++ b/backend/tests/logout_tests.rs
@@ -1,0 +1,32 @@
+use actix_web::{http::StatusCode, test};
+
+mod test_utils;
+use test_utils::{setup_test_app, create_org, create_user};
+
+#[actix_rt::test]
+async fn logout_clears_cookie() {
+    let Ok((app, pool)) = setup_test_app().await else { return; };
+    let org_id = create_org(&pool, "Logout Org").await;
+    create_user(&pool, org_id, "logout@example.com", "user").await;
+
+    let payload = serde_json::json!({"email": "logout@example.com", "password": "password"});
+    let login_req = test::TestRequest::post()
+        .uri("/api/login")
+        .set_json(&payload)
+        .to_request();
+    let login_resp = test::call_service(&app, login_req).await;
+    assert_eq!(login_resp.status(), StatusCode::OK);
+    assert!(login_resp.response().cookies().any(|c| c.name() == "token"));
+
+    let req = test::TestRequest::post()
+        .uri("/api/logout")
+        .to_request();
+    let resp = test::call_service(&app, req).await;
+    assert_eq!(resp.status(), StatusCode::OK);
+
+    let token_cookie = resp.response().cookies().find(|c| c.name() == "token");
+    assert!(token_cookie.is_some());
+    let cookie = token_cookie.unwrap();
+    assert!(cookie.value().is_empty());
+    assert_eq!(cookie.max_age(), Some(actix_web::cookie::time::Duration::ZERO));
+}


### PR DESCRIPTION
## Summary
- add `/api/logout` handler that clears the token cookie
- register logout endpoint
- test that logout removes the token cookie

## Testing
- `cargo test --no-run`
- `cargo test logout_clears_cookie -- --nocapture` *(fails: Failed to connect to test database)*

------
https://chatgpt.com/codex/tasks/task_e_686af7674dfc8333b75fa4a4e0f8d4f7