### PR TITLE
Add job detail SSE endpoint

### DIFF
--- a/backend/src/handlers/job.rs
+++ b/backend/src/handlers/job.rs
@@ -78,6 +78,44 @@ async fn job_events(path: web::Path<Uuid>, pool: web::Data<PgPool>) -> Sse<Chann
     rx
 }
 
+/// Stream status events for a single job via Redis Pub/Sub.
+#[get("/jobs/{id}/detail_events")]
+#[tracing::instrument]
+async fn job_detail_events(path: web::Path<Uuid>) -> Sse<ChannelStream> {
+    let job_id = *path;
+    let redis_url = match std::env::var("REDIS_URL") {
+        Ok(u) => u,
+        Err(_) => return sse::channel(0).1,
+    };
+    let client = match redis::Client::open(redis_url) {
+        Ok(c) => c,
+        Err(_) => return sse::channel(0).1,
+    };
+    let mut conn = match client.get_async_connection().await {
+        Ok(c) => c.into_pubsub(),
+        Err(_) => return sse::channel(0).1,
+    };
+    if conn.subscribe("job_status").await.is_err() {
+        return sse::channel(0).1;
+    }
+    let (tx, rx) = sse::channel(10);
+    actix_web::rt::spawn(async move {
+        let mut stream = conn.on_message();
+        while let Some(msg) = stream.next().await {
+            if let Ok(payload) = msg.get_payload::<String>() {
+                if let Ok(event) = serde_json::from_str::<JobEvent>(&payload) {
+                    if event.job_id == job_id {
+                        if tx.send(sse::Data::new(payload)).await.is_err() {
+                            break;
+                        }
+                    }
+                }
+            }
+        }
+    });
+    rx
+}
+
 /// Stream job status events for an organization via Redis Pub/Sub.
 #[get("/jobs/events/{org_id}")]
 #[tracing::instrument]
@@ -225,6 +263,7 @@ async fn get_job_details(
 pub fn routes(cfg: &mut web::ServiceConfig) {
     cfg.service(list_jobs)
         .service(job_events)
+        .service(job_detail_events)
         .service(org_job_events)
         .service(get_job_details)
         .service(get_stage_output_download_url);

--- a/frontend/src/lib/api/index.ts
+++ b/frontend/src/lib/api/index.ts
@@ -803,6 +803,42 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/jobs/{id}/detail_events": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Stream job status events */
+        get: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    id: string;
+                };
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description Event stream */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+            };
+        };
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/jobs/events/{org_id}": {
         parameters: {
             query?: never;

--- a/frontend/src/lib/components/AnalysisJobDetail.svelte
+++ b/frontend/src/lib/components/AnalysisJobDetail.svelte
@@ -1,13 +1,17 @@
 <script lang="ts">
-  import { onMount, createEventDispatcher } from 'svelte';
+  import { onMount, onDestroy, createEventDispatcher } from 'svelte';
   import GlassCard from './GlassCard.svelte';
   import Button from './Button.svelte';
   import Modal from './Modal.svelte';
   import * as Diff from 'diff'; // Import the diff library
   import { apiFetch } from '$lib/utils/apiUtils';
   import { errorStore } from '$lib/utils/errorStore';
+  import { createReconnectingEventSource, type ReconnectingEventSource } from '$lib/utils/eventSourceUtils';
 
   export let jobId: string;
+
+  let eventSource: ReconnectingEventSource | null = null;
+  let pollTimer: ReturnType<typeof setInterval> | null = null;
 
   // Updated TypeScript Interfaces
   interface StageOutput {
@@ -169,13 +173,58 @@
     }
   }
 
-  onMount(() => {
+  function startPolling() {
+    if (pollTimer) return;
     if (jobId) {
       fetchJobDetails(jobId);
+      pollTimer = setInterval(() => fetchJobDetails(jobId), 10000);
+    }
+  }
+
+  function stopPolling() {
+    if (pollTimer) {
+      clearInterval(pollTimer);
+      pollTimer = null;
+    }
+  }
+
+  function handleEvent(e: MessageEvent) {
+    try {
+      const data = JSON.parse(e.data);
+      if (jobDetails) jobDetails.status = data.status;
+      if (data.status === 'completed' || data.status === 'failed') {
+        fetchJobDetails(jobId);
+      }
+    } catch {}
+  }
+
+  function startStream() {
+    if (!jobId || typeof EventSource === 'undefined') {
+      startPolling();
+      return;
+    }
+    startPolling();
+    eventSource = createReconnectingEventSource(
+      `/api/jobs/${jobId}/detail_events`,
+      handleEvent,
+      1000,
+      () => stopPolling(),
+      () => startPolling()
+    );
+  }
+
+  onMount(() => {
+    if (jobId) {
+      startStream();
     } else {
       error = "Job ID is missing.";
       isLoading = false;
     }
+  });
+
+  onDestroy(() => {
+    eventSource?.close();
+    stopPolling();
   });
 
   // Reactive fetch if jobId changes (optional, as App.svelte remounts it)


### PR DESCRIPTION
## Summary
- stream job state updates via `/jobs/{id}/detail_events`
- update Svelte job detail modal to consume SSE and poll on failure
- document new path in generated API types

## Testing
- `cargo fmt --manifest-path backend/Cargo.toml --all -- --check` *(fails: rustfmt missing)*
- `cargo clippy --manifest-path backend/Cargo.toml --all-targets -- --deny warnings` *(fails: clippy missing)*
- `cargo test --manifest-path backend/Cargo.toml` *(compilation started but was canceled due to environment limits)*
- `npm install --prefix frontend`
- `npm run lint --prefix frontend` *(fails with Svelte type errors)*
- `npm test --prefix frontend` *(canceled after errors)*
- `npm run build --prefix frontend`


------
https://chatgpt.com/codex/tasks/task_e_686af767e8c48333987a74ac659bba0e