### PR TITLE
Add pipeline pagination and search

### DIFF
--- a/backend/src/models/pipeline.rs
+++ b/backend/src/models/pipeline.rs
@@ -48,4 +48,55 @@ impl Pipeline {
             .await?;
         Ok(res.rows_affected())
     }
+
+    /// List pipelines by organization with optional search and pagination.
+    pub async fn list_paginated(
+        pool: &PgPool,
+        org_id: Uuid,
+        search: Option<String>,
+        page: i64,
+        limit: i64,
+    ) -> sqlx::Result<(Vec<Pipeline>, i64)> {
+        let offset = (page - 1) * limit;
+        if let Some(term) = search {
+            let like_term = format!("%{}%", term);
+            let items = sqlx::query_as::<_, Pipeline>(
+                "SELECT * FROM pipelines WHERE org_id=$1 AND name ILIKE $2 ORDER BY name ASC LIMIT $3 OFFSET $4",
+            )
+            .bind(org_id)
+            .bind(&like_term)
+            .bind(limit)
+            .bind(offset)
+            .fetch_all(pool)
+            .await?;
+
+            let total = sqlx::query_scalar::<_, i64>(
+                "SELECT COUNT(*) FROM pipelines WHERE org_id=$1 AND name ILIKE $2",
+            )
+            .bind(org_id)
+            .bind(&like_term)
+            .fetch_one(pool)
+            .await?;
+
+            Ok((items, total))
+        } else {
+            let items = sqlx::query_as::<_, Pipeline>(
+                "SELECT * FROM pipelines WHERE org_id=$1 ORDER BY name ASC LIMIT $2 OFFSET $3",
+            )
+            .bind(org_id)
+            .bind(limit)
+            .bind(offset)
+            .fetch_all(pool)
+            .await?;
+
+            let total = sqlx::query_scalar::<_, i64>(
+                "SELECT COUNT(*) FROM pipelines WHERE org_id=$1",
+            )
+            .bind(org_id)
+            .fetch_one(pool)
+            .await?;
+
+            Ok((items, total))
+        }
+    }
 }


### PR DESCRIPTION
## Summary
- support pagination & search params in pipeline list backend endpoint
- implement `list_paginated` helper in Pipeline model
- add pagination and search UI to pipeline page

## Testing
- `npm test` *(fails: vitest not found)*
- `cargo test` *(fails: Failed to connect to test database)*

------
https://chatgpt.com/codex/tasks/task_e_686b9bfa34dc8333b20803dc6c2e8e85