### PR TITLE
Implement logout endpoint

### DIFF
--- a/backend/src/handlers/auth.rs
+++ b/backend/src/handlers/auth.rs
@@ -208,6 +208,16 @@ pub async fn login(
     }
 }
 
+#[post("/logout")]
+#[tracing::instrument]
+async fn logout() -> HttpResponse {
+    let cookie = actix_web::cookie::Cookie::build("token", "")
+        .path("/")
+        .max_age(ActixDuration::ZERO)
+        .finish();
+    HttpResponse::Ok().cookie(cookie).finish()
+}
+
 #[get("/confirm/{token}")]
 #[tracing::instrument(skip(pool))]
 async fn confirm(path: web::Path<Uuid>, pool: web::Data<PgPool>) -> HttpResponse {
@@ -264,6 +274,7 @@ async fn reset_password(data: web::Json<ResetInput>, pool: web::Data<PgPool>) ->
 pub fn routes(cfg: &mut web::ServiceConfig) {
     cfg.service(register)
         .service(login)
+        .service(logout)
         .service(me)
         .service(confirm)
         .service(request_reset)

--- a/backend/src/handlers/mod.rs
+++ b/backend/src/handlers/mod.rs
@@ -13,6 +13,7 @@ pub mod admin; // New module
 
 pub fn init(cfg: &mut web::ServiceConfig) {
     cfg.service(web::scope("/api")
+        .service(auth::logout)
         .configure(auth::routes)
         .configure(org::routes)
         .configure(document::routes)

--- a/backend/tests/logout.rs
+++ b/backend/tests/logout.rs
@@ -1,0 +1,23 @@
+use actix_web::cookie::time::Duration;
+use actix_web::{http::StatusCode, test, web, App};
+use backend::handlers;
+
+#[actix_rt::test]
+async fn logout_clears_cookie() {
+    let app = test::init_service(
+        App::new().service(web::scope("/api").service(backend::handlers::auth::logout)),
+    )
+    .await;
+
+    let req = test::TestRequest::post().uri("/api/logout").to_request();
+    let resp = test::call_service(&app, req).await;
+
+    assert_eq!(resp.status(), StatusCode::OK);
+    let cookie = resp
+        .response()
+        .cookies()
+        .find(|c| c.name() == "token")
+        .expect("token cookie");
+    assert_eq!(cookie.value(), "");
+    assert_eq!(cookie.max_age(), Some(Duration::ZERO));
+}


### PR DESCRIPTION
## Summary
- add `/api/logout` endpoint in backend
- register logout route
- test logout cookie behavior

## Testing
- `cargo test logout_clears_cookie -- --nocapture` *(fails: could not finish due to environment limitations)*

------
https://chatgpt.com/codex/tasks/task_e_686b9bf992f08333855c3d8222bcd626