### PR TITLE
Improve pipeline editor UX

### DIFF
--- a/frontend/src/lib/components/PipelineEditor.svelte
+++ b/frontend/src/lib/components/PipelineEditor.svelte
@@ -153,6 +153,8 @@
       pipeline.stages = [...pipeline.stages, newStage];
       newStageType = '';
       newCommand = '';
+    } else {
+      errorStore.show('Please enter a stage type.');
     }
   }
 

--- a/frontend/src/lib/components/pipeline_editor/StageItem.svelte
+++ b/frontend/src/lib/components/pipeline_editor/StageItem.svelte
@@ -33,11 +33,11 @@
 </script>
 
 <div
-  class={`stage-item p-4 rounded-lg cursor-grab border-2 ${
-    dragState.draggingVisualIndex === index ? 'dragging !border-accent' : 'border-neutral-700/70'
+  class={`stage-item card glass p-4 cursor-grab border ${
+    dragState.draggingVisualIndex === index ? 'dragging border-accent' : 'border-neutral-700/70'
   } ${
     dragState.draggedOverIndex === index && dragState.draggedItemId !== stage.id
-      ? 'drag-over-highlight !border-accent'
+      ? 'drag-over-highlight border-accent'
       : 'hover:border-neutral-600'
   }`}
   draggable="true"

--- a/frontend/src/lib/components/pipeline_editor/StageList.svelte
+++ b/frontend/src/lib/components/pipeline_editor/StageList.svelte
@@ -106,4 +106,23 @@
       on:dragend={handleDragEnd}
     />
   {/each}
+  <div
+    class="h-10 flex items-center justify-center border-2 border-dashed rounded-lg text-sm text-gray-400"
+    class:drag-target-active={dragState.draggedOverIndex === stages.length}
+    on:dragover={(e) => handleDragOver(e, stages.length)}
+    on:dragenter={(e) => handleDragEnter(e, stages.length)}
+    on:dragleave={handleDragLeave}
+    on:drop={(e) => handleDrop(e, stages.length)}
+  >
+    {#if dragState.draggedItemId && dragState.draggedOverIndex === stages.length}
+      Drop here to add at end
+    {/if}
+  </div>
 </div>
+
+<style>
+  .drag-target-active {
+    border-color: var(--fallback-bc,theme(colors.accent));
+    background-color: rgb(59 130 246 / 0.1);
+  }
+</style>

--- a/frontend/src/lib/stores/uiState.ts
+++ b/frontend/src/lib/stores/uiState.ts
@@ -62,6 +62,14 @@ function createUiStateStore() {
       update((state) => ({ ...state, currentViewedJobId: id })),
     closeJobDetails: () =>
       update((state) => ({ ...state, currentViewedJobId: null })),
+    closeAll: () =>
+      update((state) => ({
+        ...state,
+        showSettingsPanel: false,
+        showPipelineEditorPanel: false,
+        showAdmin: false,
+        currentViewedJobId: null
+      })),
     reset: () => set(initialState)
   };
 }

--- a/frontend/src/routes/+layout.svelte
+++ b/frontend/src/routes/+layout.svelte
@@ -15,6 +15,7 @@
   import { apiFetch } from '$lib/utils/apiUtils';
   import ErrorToast from '$lib/components/ErrorToast.svelte';
   import { sessionStore } from '$lib/stores/session';
+  import { uiStateStore } from '$lib/stores/uiState';
 
   // Type Imports or Definitions
   export interface NavItem {
@@ -76,6 +77,19 @@
 
   $: if (org) {
     loadAccentColor();
+  }
+
+  let prevPath = '';
+  $: {
+    const newPath = $page.url.pathname;
+    if (newPath !== prevPath) {
+      prevPath = newPath;
+      showSettingsPanel = false;
+      showPipelineEditorPanel = false;
+      currentViewedJobId = null;
+      pipelineToEdit = null;
+      uiStateStore.closeAll();
+    }
   }
 
   // Define Pipeline type (consistent with PipelineEditor's expectation)


### PR DESCRIPTION
## Summary
- tweak StageItem styling for DaisyUI look
- allow dropping new stages at the end of StageList
- show toast error when adding stage without type
- add `closeAll` helper to `uiStateStore`
- close overlays on route change in the main layout

## Testing
- `npm test` *(fails: vitest not found)*
- `npm run lint` *(fails: svelte-check not found)*

------
https://chatgpt.com/codex/tasks/task_e_686c322758108333a21345895d89c19a