### PR TITLE
Implement polling fallback for SSE

### DIFF
--- a/frontend/src/lib/utils/eventSourceUtils.ts
+++ b/frontend/src/lib/utils/eventSourceUtils.ts
@@ -50,3 +50,56 @@ export function createReconnectingEventSource(
 
   return { getEventSource, close };
 }
+
+export interface EventStream {
+  close(): void;
+}
+
+/**
+ * Create an event stream that uses SSE when available and falls back to polling
+ * via the provided `pollFn` when SSE is unavailable or reconnecting.
+ */
+export function createEventStreamWithFallback(
+  url: string,
+  onMessage: (e: MessageEvent) => void,
+  pollFn: () => Promise<void>,
+  pollInterval = 10000,
+  retryDelay = 1000,
+): EventStream {
+  let es: ReconnectingEventSource | null = null;
+  let pollTimer: ReturnType<typeof setInterval> | null = null;
+
+  const startPolling = () => {
+    if (pollTimer) return;
+    pollFn();
+    pollTimer = setInterval(pollFn, pollInterval);
+  };
+
+  const stopPolling = () => {
+    if (pollTimer) {
+      clearInterval(pollTimer);
+      pollTimer = null;
+    }
+  };
+
+  if (typeof EventSource === 'undefined') {
+    startPolling();
+    return { close: stopPolling };
+  }
+
+  startPolling();
+  es = createReconnectingEventSource(
+    url,
+    onMessage,
+    retryDelay,
+    () => stopPolling(),
+    () => startPolling()
+  );
+
+  return {
+    close() {
+      es?.close();
+      stopPolling();
+    }
+  };
+}


### PR DESCRIPTION
## Summary
- add `createEventStreamWithFallback` helper to use SSE when available and poll otherwise
- use new helper in `JobsList.svelte` and `AnalysisJobDetail.svelte`
- test polling fallback logic

## Testing
- `npm install` in `frontend`
- `npx vitest run` *(fails: Button.test.ts and others)*

------
https://chatgpt.com/codex/tasks/task_e_686c32290d3c833389292da56e83a68b