### PR TITLE
Ensure pipeline cache invalidation

### DIFF
--- a/backend/src/handlers/auth.rs
+++ b/backend/src/handlers/auth.rs
@@ -271,13 +271,6 @@ async fn reset_password(data: web::Json<ResetInput>, pool: web::Data<PgPool>) ->
     }
 }
 
-#[post("/logout")]
-async fn logout() -> HttpResponse {
-    let cookie = actix_web::cookie::Cookie::build("token", "")
-        .max_age(ActixDuration::ZERO)
-        .finish();
-    HttpResponse::Ok().cookie(cookie).finish()
-}
 
 pub fn routes(cfg: &mut web::ServiceConfig) {
     cfg.service(register)

--- a/backend/src/handlers/pipeline.rs
+++ b/backend/src/handlers/pipeline.rs
@@ -264,11 +264,14 @@ async fn update_pipeline(
             cache_invalidate(existing.org_id).await;
             HttpResponse::Ok().json(p)
         }
-        Err(_) => ApiError::new(
-            "Failed to update pipeline",
-            StatusCode::INTERNAL_SERVER_ERROR,
-        )
-        .error_response(),
+        Err(_) => {
+            cache_invalidate(existing.org_id).await;
+            ApiError::new(
+                "Failed to update pipeline",
+                StatusCode::INTERNAL_SERVER_ERROR,
+            )
+            .error_response()
+        }
     }
 }
 
@@ -308,11 +311,14 @@ async fn delete_pipeline(
             cache_invalidate(existing.org_id).await;
             HttpResponse::Ok().finish()
         }
-        Err(_) => ApiError::new(
-            "Failed to delete pipeline",
-            StatusCode::INTERNAL_SERVER_ERROR,
-        )
-        .error_response(),
+        Err(_) => {
+            cache_invalidate(existing.org_id).await;
+            ApiError::new(
+                "Failed to delete pipeline",
+                StatusCode::INTERNAL_SERVER_ERROR,
+            )
+            .error_response()
+        }
     }
 }
 
@@ -357,11 +363,14 @@ async fn clone_pipeline(
             cache_invalidate(existing.org_id).await;
             HttpResponse::Ok().json(p)
         }
-        Err(_) => ApiError::new(
-            "Failed to clone pipeline",
-            StatusCode::INTERNAL_SERVER_ERROR,
-        )
-        .error_response(),
+        Err(_) => {
+            cache_invalidate(existing.org_id).await;
+            ApiError::new(
+                "Failed to clone pipeline",
+                StatusCode::INTERNAL_SERVER_ERROR,
+            )
+            .error_response()
+        }
     }
 }
 


### PR DESCRIPTION
## Summary
- remove duplicate logout handler
- invalidate cache on pipeline update, delete and clone attempts

## Testing
- `cargo test --manifest-path backend/Cargo.toml --no-run`
- `npm install --prefix frontend`
- `npm run lint --prefix frontend` *(fails: svelte-check found 145 errors)*
- `npm test --prefix frontend` *(partial, tests skipped)*
- `npm run build --prefix frontend`


------
https://chatgpt.com/codex/tasks/task_e_686c322adc8483338e580ef0d4fb4ed6